### PR TITLE
Simplify Contact Form

### DIFF
--- a/contact/contact_send.php
+++ b/contact/contact_send.php
@@ -31,8 +31,8 @@ $contact_email = fetch_POST('contact_email');
 $contact_phone = fetch_POST('contact_phone');
 
 $contact_date = date('d-M-Y H:i');
-$contact_type = fetch_POST('contact_type');
-$contact_message = fetch_POST('contact_message');
+$subject = fetch_POST('subject');
+$description = fetch_POST('description');
 
 $app_www = APP__WWW;
 
@@ -42,8 +42,8 @@ if ($contact_fullname == '') {
 	$errors[] = 'Name is required';
 }
 
-if ($contact_message == '') {
-	$errors[] = 'Message is required';
+if ($description == '') {
+	$errors[] = 'Description is required';
 }
 
 if ($contact_email == '') {
@@ -59,7 +59,7 @@ $email_body = <<<EndBody
 Contact Sent
 ----------------------------------------
 Application  : $contact_app_id ($app_www)
-Contact Type : $contact_type
+Subject      : $subject
 Date         : $contact_date
 ----------------------------------------
 
@@ -79,9 +79,9 @@ Username : $contact_user_username
 Email    : $contact_user_email
 ----------------------------------------
 
-Message:
+Description:
 ----------------------------------------
-$contact_message
+$description
 ----------------------------------------
 EndBody;
 
@@ -89,7 +89,7 @@ EndBody;
 $email = new Email();
 $email->set_to($contact_to);
 $email->set_from($contact_email);
-$email->set_subject("$contact_app_id : $contact_type");
+$email->set_subject("$contact_app_id : $subject");
 $email->set_body($email_body);
 $email->send();
 

--- a/contact/index.php
+++ b/contact/index.php
@@ -15,10 +15,6 @@ require_once('../includes/functions/lib_form_functions.php');
 
 check_user($_user);
 
-// Process GET/POST
-
-$contact_type = fetch_GET('q');
-
 // Begin Page
 
 $UI->page_title = APP__NAME . ' Contact';
@@ -45,10 +41,8 @@ $UI->body();
 $UI->content_start();
 
 ?>
-	<p>If you want to report a problem or bug with any part of the WebPA system, have a technical query, or just need to ask a specific question regarding WebPA, please complete the form below.</p>
-
 	<div class="content_box">
-		<p>Please supply as much information with your message as possible (especially when sending a bug report!), this will allow us to respond to your message much faster!</p>
+		<h2>We're sorry something is wrong. How can we help?</h2>
 
 		<form action="contact_send.php" method="post" name="contact_form">
 		<input type="hidden" name="contact_app" value="<?php echo($_config['app_id']); ?>" />
@@ -56,41 +50,52 @@ $UI->content_start();
 		<div class="form_section">
 			<table class="form" cellpadding="2" cellspacing="2">
 			<tr>
-				<td><label for="contact_name">Your Name</label></td>
-				<td><input type="text" name="contact_name" id="contact_name" maxlength="60" size="50" value="<?php echo("{$_user->forename} {$_user->lastname}"); ?>" /></td>
-			</tr>
-			<tr>
-				<td><label for="contact_username">Your Username</label></td>
-				<td><input type="text" name="contact_username" id="contact_username" maxlength="15" size="10" value="<?php echo($_user->username); ?>" /></td>
-			</tr>
-			<tr>
-				<td><label for="contact_email">Your Email</label></td>
-				<td><input type="text" name="contact_email" id="contact_email" maxlength="255" size="50" value="<?php echo($_user->email); ?>" /></td>
-			</tr>
-			<tr>
-				<td><label for="contact_phone">Your Phone Number</label></td>
-				<td><input type="text" name="contact_phone" id="contact_phone" maxlength="25" size="20" value="" /></td>
-			</tr>
-			<tr><td colspan="2">&nbsp;</td></tr>
-			<tr>
-				<td><label for="contact_type">Type of Message</label></td>
 				<td>
-					<select name="contact_type" id="contact_type">
-						<?php
-							$contact_types = array	('help'		=> 'Request for help!' ,
-													 'info'		=> 'Information request' ,
-													 'bug'		=> 'Bug / Error report' ,
-													 'wish'		=> 'Suggestion / Wish List' ,
-													 'misc'		=> 'Other type of message' ,);
-
-							render_options($contact_types, $contact_type);
-						?>
-					</select>
+                    <label for="contact_name">Your name</label>
+                </td>
+				<td>
+                    <input type="text" name="contact_name" id="contact_name" maxlength="60" size="50" value="<?= "{$_user->forename} {$_user->lastname}"; ?>">
+                </td>
+			</tr>
+			<tr>
+				<td>
+                    <label for="contact_username">Your username</label>
+                </td>
+				<td>
+                    <input type="text" name="contact_username" id="contact_username" maxlength="15" size="10" value="<?= $_user->username; ?>">
+                </td>
+			</tr>
+			<tr>
+				<td>
+                    <label for="contact_email">Your email address</label>
+                </td>
+				<td>
+                    <input type="text" name="contact_email" id="contact_email" maxlength="255" size="50" value="<?= $_user->email; ?>">
+                </td>
+			</tr>
+			<tr>
+				<td>
+                    <label for="contact_phone">Your phone number</label>
+                </td>
+				<td>
+                    <input type="text" name="contact_phone" id="contact_phone" maxlength="25" size="20">
+                </td>
+			</tr>
+			<tr>
+				<td>
+                    <label for="subject">Subject</label>
+                </td>
+				<td>
+                    <input type="text" name="subject" id="subject">
 				</td>
 			</tr>
 			<tr>
-				<td><label for="contact_message">Message Text</label></td>
-				<td><textarea name="contact_message" id="contact_message" cols="60" rows="6"></textarea></td>
+				<td>
+                    <label for="description">Description</label>
+                </td>
+				<td>
+                    <textarea name="description" id="description" cols="60" rows="6"></textarea>
+                </td>
 			</tr>
 			</table>
 		</div>

--- a/contact/index.php
+++ b/contact/index.php
@@ -17,7 +17,7 @@ check_user($_user);
 
 // Begin Page
 
-$UI->page_title = APP__NAME . ' Contact';
+$UI->page_title = APP__NAME . ' Contact Support';
 $UI->menu_selected = 'contact';
 $UI->help_link = '?q=node/379#intool';
 $UI->breadcrumbs = array	('home'		=> '../' ,

--- a/includes/classes/class_ui.php
+++ b/includes/classes/class_ui.php
@@ -415,21 +415,15 @@ class UI {
 <?php
     if ($render_menu) {
       $this->menu();
-?>
-    <div class="alert_box" style="margin: 40px 8px 8px 8px; font-size: 0.7em;">
-      <p><strong>Technical Problem?</strong></p>
-      <p>If you have a problem, find a bug or discover a technical problem in the system, <a href="<?php echo APP__WWW ?>/contact/index.php?q=bug">contact us</a> to report it!</p>
-    </div>
-<?php
-    } else {
-?>
-    <div class="alert_box" style="margin: 40px 8px 8px 8px; font-size: 0.7em;">
-      <p><strong>Technical Problem?</strong></p>
-      <p>If you have a problem, find a bug or discover a technical problem in the system, please <a href="mailto:<?php echo $BRANDING['email.help']; ?>" title="(email: <?php echo $BRANDING['email.help']; ?>)">email us</a> to report it!</p>
-    </div>
-<?php
     }
 ?>
+    <div class="alert_box" style="margin: 40px 8px 8px 8px; font-size: 0.7em;">
+      <p><strong>Report a Bug</strong></p>
+        <p>
+            If you have found a bug in WebPA, please report it by creating an issue in WebPA's
+            <a href="https://github.com/webpa/webpa/issues">GitHub issue tracker</a>
+        </p>
+    </div>
 </div>
 <?php
     if ($render_header) {

--- a/includes/inc_global.php
+++ b/includes/inc_global.php
@@ -19,8 +19,8 @@ date_default_timezone_set('Europe/London');
 // User configuration section
 ////
 
-define('APP__WWW', '');
-define('DOC__ROOT', ''); //must include the trailing /
+define('APP__WWW', 'http://env.test');
+define('DOC__ROOT', '/var/www/'); //must include the trailing /
 define('CUSTOM_CSS', '');  // Optional custom CSS file
 define('SESSION_NAME', 'WEBPA');
 ini_set('session.cookie_path', '/');
@@ -29,10 +29,10 @@ ini_set('session.cookie_path', '/');
 define('APP__ACADEMIC_YEAR_START_MONTH', 9);
 
 //Database information
-define('APP__DB_HOST', 'localhost'); // If on a non-standard port, use this format:  <server>:<port>
-define('APP__DB_USERNAME', '');
-define('APP__DB_PASSWORD', '');
-define('APP__DB_DATABASE', '');
+define('APP__DB_HOST', 'db'); // If on a non-standard port, use this format:  <server>:<port>
+define('APP__DB_USERNAME', 'root');
+define('APP__DB_PASSWORD', 'uUiK:8#P([>N{-!U7{DQ>y8^vsJ');
+define('APP__DB_DATABASE', 'webpa');
 define('APP__DB_TABLE_PREFIX', 'pa2_');
 
 // Contact info


### PR DESCRIPTION
We had reports of students being confused by the contact form and its various _message types_. Regardless of the message type set, the email is always sent from the email address defined in `APP__EMAIL_HELP`. 

Setting the message type simply changes the subject and notes the message type selected in the body of the email. While this is useful for filtering, I believe it is simpler to just let students assume the contact us form is going to the same email address, regardless of what information they select.

For this reason, the contact us form now has a simple _Subject_ and _Description_ section instead.

I have also updated the _Technical Problem?_ box displayed on the left of WebPA to ask users to report bugs to this issue tracker.