### PR TITLE
Update academic year pull down menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug where only one year value can be displayed in the assessments and metrics academic year drop down (PR #42)
+
 ## [3.0.1] - 2018-11-07
 
 ### Fixed

--- a/includes/classes/class_engcis.php
+++ b/includes/classes/class_engcis.php
@@ -540,14 +540,14 @@ class EngCIS
             $sql = 'SELECT MIN(a.open_date) first, MAX(a.open_date) last ' .
                 'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
                 'INNER JOIN ' . APP__DB_TABLE_PREFIX . 'module m ON a.module_id = m.module_id ' .
-                "WHERE m.source_id = '{$_source_id}' AND m.module_id = '{$_module_id}' " .
-                'GROUP BY a.assessment_id';
+                "WHERE m.source_id = '{$_source_id}' AND m.module_id = '{$_module_id}' ";
+               
         } else {
             $sql = 'SELECT MIN(a.open_date) first, MAX(a.open_date) last ' .
                 'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
                 'INNER JOIN ' . APP__DB_TABLE_PREFIX . 'module m ON a.module_id = m.module_id ' .
-                "WHERE m.source_id = '{$_source_id}' " .
-                'GROUP BY a.assessment_id';
+                "WHERE m.source_id = '{$_source_id}' ";
+              
         }
         $dates = $this->_DAO->fetch_row($sql);
         if (!empty($dates)) {

--- a/includes/classes/class_engcis.php
+++ b/includes/classes/class_engcis.php
@@ -531,25 +531,24 @@ class EngCIS
         }
     }// /->_order_by_clause()
 
-    function get_user_academic_years($user_id = NULL)
+    function get_user_academic_years($user_id = null)
     {
-
         global $_source_id, $_module_id;
 
         if (!empty($user_id)) {
             $sql = 'SELECT MIN(a.open_date) first, MAX(a.open_date) last ' .
                 'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
                 'INNER JOIN ' . APP__DB_TABLE_PREFIX . 'module m ON a.module_id = m.module_id ' .
-                "WHERE m.source_id = '{$_source_id}' AND m.module_id = '{$_module_id}' ";
-               
+                "WHERE m.source_id = '{$_source_id}' AND m.module_id = '{$_module_id}'";
         } else {
             $sql = 'SELECT MIN(a.open_date) first, MAX(a.open_date) last ' .
                 'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
                 'INNER JOIN ' . APP__DB_TABLE_PREFIX . 'module m ON a.module_id = m.module_id ' .
-                "WHERE m.source_id = '{$_source_id}' ";
-              
+                "WHERE m.source_id = '{$_source_id}'";
         }
+
         $dates = $this->_DAO->fetch_row($sql);
+
         if (!empty($dates)) {
             $years[] = dateToYear(strtotime($dates['first']));
             $years[] = dateToYear(strtotime($dates['last']));
@@ -559,8 +558,7 @@ class EngCIS
         }
 
         return $years;
-
-    }// /get_first_academic_year()
+    }
 
 }// /class: EngCIS
 


### PR DESCRIPTION
The code used a GROUP BY clause which resulted in one row per assignment but the code only looked at the first row and that only has one date so the first and last were set the same

By removing the GROUP BY clause the query only returns one result with the correct range of dates for all assignments.  The pull down menu now returns the correct results