### PR TITLE
Ensure connection object is removed when closing connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.2] - 2018-11-20
+
+### Fixed
+- Fixed a bug where the database connection was not being properly closed down, meaning subsequent database calls would always fail, even if the `$DB->open()` function was called as the old, closed connection would not be replaced or reinstantiated (PR #43)
+
 ### Fixed
 - Fixed a bug where only one year value can be displayed in the assessments and metrics academic year drop down (PR #42)
 
@@ -29,7 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.1.0.1] - 2008-07-19
 
-[Unreleased]: https://github.com/WebPA/WebPA/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/WebPA/WebPA/compare/v3.0.2...HEAD
+[3.0.2]: https://github.com/WebPA/WebPA/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/WebPA/WebPA/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/WebPA/WebPA/compare/v2.0.0.11...v3.0.0
 [2.0.0.11]: https://github.com/WebPA/WebPA/compare/v1.1.0.1...v2.0.0.11

--- a/includes/classes/class_dao.php
+++ b/includes/classes/class_dao.php
@@ -116,8 +116,11 @@ class DAO
     function close()
     {
         $this->flush();
-        return (@mysqli_close($this->_conn));
-    } // /->close()
+        $isClosed = @mysqli_close($this->_conn);
+        $this->_conn = null;
+
+        return $isClosed;
+    }
 
     /**
      * Clear results and reset result vars

--- a/includes/classes/class_dao.php
+++ b/includes/classes/class_dao.php
@@ -110,8 +110,9 @@ class DAO
     } // /->open()
 
     /**
-     * Close database connection
-     * @return object
+     * Close database connection.
+     *
+     * @return bool
      */
     function close()
     {


### PR DESCRIPTION
The `close()` function in the class_dao did not work properly. It closed the MySQL connection but did not remove the original mysqli connection object, meaning all subsequent mysql queries would fail.

This is because when calling the `open()` function, we will only reinitialise the mysql connection if the `_conn` property is null. When calling `close()`, the `_conn` property is not null, but it has no valid connection to the MySQL server.