### PR TITLE
Fix Database Errors

### DIFF
--- a/includes/classes/class_dao.php
+++ b/includes/classes/class_dao.php
@@ -199,7 +199,7 @@ class DAO
         if ($sql) {
             $this->_process_query($sql);
         }
-        return (isset($this->_result)) ? $this->_result[$y] : null;
+        return isset($this->_result[$y]) ? $this->_result[$y] : null;
     } // /->fetch_row()
 
     /**

--- a/includes/classes/class_result_handler.php
+++ b/includes/classes/class_result_handler.php
@@ -140,7 +140,7 @@ class ResultHandler {
           INNER JOIN " . APP__DB_TABLE_PREFIX . "assessment a ON um.assessment_id = a.assessment_id
         WHERE um.assessment_id = '{$this->_assessment->id}'
           AND a.collection_id = '{$this->_collection->id}'
-          AND um,group_id = '$group_id'
+          AND um.group_id = '$group_id'
       ");
     } else {
       return null;

--- a/login_check.php
+++ b/login_check.php
@@ -29,7 +29,6 @@ $password = substr($password,0,255);
 $DB->open();
 $username = $DB->escape_str($username);
 $password = $DB->escape_str($password);
-$DB->close();
 
 $msg ='';
 

--- a/tutors/assessments/create/class_wizardstep_6.php
+++ b/tutors/assessments/create/class_wizardstep_6.php
@@ -74,7 +74,6 @@ class WizardStep6 {
     $form = new Form($DB);
     $form->load($this->wizard->get_field('form_id'));
     $assessment->set_form_xml( $form->get_xml() );
-    $assessment->save();
 
     // Set the collection of groups to assess
     $group_handler = new GroupHandler();


### PR DESCRIPTION
Fixes issue #45 

- Fix undefined offset notice in the `class_dao.php` file
- Fix respondent list for assessments not showing
- Fix login issue where activity timestamp was not being stored in the database
- Fix issue preventing users from creating assessments via the assessment wizard