### PR TITLE
Fix issue #57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- When viewing assessments in a module, if no assessment has been created the dropdown will display the years 1969/70. This has now been fixed to display the current academic year instead (PR #58)
+
 ## [3.0.3] - 2019-03-21
 
 ### Fixed

--- a/includes/classes/class_engcis.php
+++ b/includes/classes/class_engcis.php
@@ -378,20 +378,20 @@ class EngCIS
             $order_by_clause = $this->_order_by_clause('user', $ordering);
 
             $sql = "SELECT u.*, um.user_type
-              FROM " . APP__DB_TABLE_PREFIX . "user u 
-              LEFT OUTER JOIN " . APP__DB_TABLE_PREFIX . "user_module um 
+              FROM " . APP__DB_TABLE_PREFIX . "user u
+              LEFT OUTER JOIN " . APP__DB_TABLE_PREFIX . "user_module um
               ON u.user_id = um.user_id
-              WHERE (u.user_id IN {$user_set}) 
+              WHERE (u.user_id IN {$user_set})
               AND (um.module_id = {$_module_id})
               $order_by_clause";
 
             return $this->_DAO->fetch($sql);
         } else {
             $sql = "SELECT u.*, um.user_type
-              FROM " . APP__DB_TABLE_PREFIX . "user u 
-              LEFT OUTER JOIN " . APP__DB_TABLE_PREFIX . "user_module um 
+              FROM " . APP__DB_TABLE_PREFIX . "user u
+              LEFT OUTER JOIN " . APP__DB_TABLE_PREFIX . "user_module um
               ON u.user_id = um.user_id
-              WHERE (u.user_id IN {$user_set}) 
+              WHERE (u.user_id IN {$user_set})
               AND (um.module_id = {$_module_id} OR u.admin = 1)
               LIMIT 1";
 
@@ -549,7 +549,8 @@ class EngCIS
 
         $dates = $this->_DAO->fetch_row($sql);
 
-        if (!empty($dates)) {
+        // Ensure that the first record contains some dates as we could return a null record
+        if (!empty($dates[0][0]) {
             $years[] = dateToYear(strtotime($dates['first']));
             $years[] = dateToYear(strtotime($dates['last']));
         } else {


### PR DESCRIPTION
No matter what happens, we will always return a max and min year due to the way the query is created. However, this record could be null. 

This fix ensures that if we receive a null value, we will return the current academic year.