### PR TITLE
Add MySQL Port Environment Variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_WWW=http://localhost
 DOC_ROOT=/var/www/webpa/
 DB_HOST=localhost
+DB_PORT=3306
 DB_USER=root
 DB_PASS=password
 DB_NAME=webpa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- You can now specify the MySQL port number in the environment variables (PR #88)
+
 ### Fixed
 - Fixed bug where students were told they had not submitted to a closed assessment when they had (PR #89)
 

--- a/src/includes/classes/DAO.php
+++ b/src/includes/classes/DAO.php
@@ -25,11 +25,11 @@ class DAO
      * @param string $user
      * @param string $password
      * @param string $database
-     * @param boolean $persistent
+     * @param int $port
      *
      * @return void
      */
-    public function __construct($host, $user, $password, $database, $persistent = false)
+    public function __construct($host, $user, $password, $database, $port = 3306)
     {
         $connectionParams = [
             'dbname' => $database,
@@ -37,6 +37,7 @@ class DAO
             'password' => $password,
             'host' => $host,
             'driver' => 'mysqli',
+            'port' => $port,
         ];
 
         $this->_conn = DriverManager::getConnection($connectionParams);

--- a/src/includes/inc_global.php
+++ b/src/includes/inc_global.php
@@ -42,7 +42,8 @@ ini_set('session.cookie_path', '/');
 define('APP__ACADEMIC_YEAR_START_MONTH', $_ENV['ACADEMIC_YEAR_START_MONTH']);
 
 //Database information
-define('APP__DB_HOST', $_ENV['DB_HOST']); // If on a non-standard port, use this format:  <server>:<port>
+define('APP__DB_HOST', $_ENV['DB_HOST']);
+define('APP__DB_PORT', $_ENV['DB_PORT']);
 define('APP__DB_USERNAME', $_ENV['DB_USER']);
 define('APP__DB_PASSWORD', $_ENV['DB_PASS']);
 define('APP__DB_DATABASE', $_ENV['DB_NAME']);
@@ -170,7 +171,7 @@ session_start();
 
 // Initialise DB object
 
-$DB = new DAO(APP__DB_HOST, APP__DB_USERNAME, APP__DB_PASSWORD, APP__DB_DATABASE);
+$DB = new DAO(APP__DB_HOST, APP__DB_USERNAME, APP__DB_PASSWORD, APP__DB_DATABASE, APP__DB_PORT);
 
 // Initialise User Object
 


### PR DESCRIPTION
At the moment, you cannot specify the MySQL port number in WebPA. This change allows you to set the port number as an environemtal variable. If it is not set, it will default to MySQL's default port number of 3306