### PR TITLE
Fix Student Assessment Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed bug where students were told they had not submitted to a closed assessment when they had (PR #XXX)
+
 ## [3.1.2] - 2020-04-22
 ### Changed
 - Emails are now triggered via a single script, `jobs/Email.php` instead of calling`tutors/asessments/email/ClosingReminder.php` and `tutors/assessments/email/TriggerReminder.php` directly. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fixed bug where students were told they had not submitted to a closed assessment when they had (PR #XXX)
+- Fixed bug where students were told they had not submitted to a closed assessment when they had (PR #89)
 
 ## [3.1.2] - 2020-04-22
 ### Changed
@@ -81,7 +81,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0.1] - 2008-07-19
 
 [Unreleased]: https://github.com/WebPA/WebPA/compare/v3.1.2...HEAD
-
 [3.1.2]: https://github.com/WebPA/WebPA/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/WebPA/WebPA/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/WebPA/WebPA/compare/v3.0.7...v3.1.0

--- a/src/students/assessments/index.php
+++ b/src/students/assessments/index.php
@@ -78,7 +78,7 @@ $assessmentsWithResponseQuery =
     'AND user_id = ? ' .
     'ORDER BY assessment_id';
 
-$assessments_with_response = $DB->getConnection()->fetchFirstColumn($assessmentsWithResponseQuery, [$assessment_ids, $_user->id], [$DB->getConnection()::PARAM_INT_ARRAY, ParameterType::INTEGER]);
+$assessments_with_response = $DB->getConnection()->fetchFirstColumn($assessmentsWithResponseQuery, [$assessment_ids, $_user->id], [$DB->getConnection()::PARAM_STR_ARRAY, ParameterType::INTEGER]);
 
 // Split the assessments into pending, open and finished
 $pending_assessments = null;


### PR DESCRIPTION
A bug was found in WebPA where students were told they had not submitted to a closed assessment, when in fact, they had. This PR fixes the bug so that if students have submitted, they are shown the correct state.