### PR TITLE
Allow Student Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Justification comments from students about why they gave scores can now be viewed by students after being moderated by academic staff (PR #97)
 
 ## [3.2.1] - 2021-12-10
 ### Fixed

--- a/src/css/webpa.css
+++ b/src/css/webpa.css
@@ -541,3 +541,6 @@ input.danger_button { background-color: #f99; }
 input.safe_button { background-color: #9f9; }
 input.warning_button { background-color: #ee9; }
 
+.hide {
+	display: none;
+}

--- a/src/includes/classes/Assessment.php
+++ b/src/includes/classes/Assessment.php
@@ -270,7 +270,7 @@ class Assessment
           ->setParameter(6, date(MYSQL_DATETIME_FORMAT, $this->close_date))
           ->setParameter(7, $this->introduction)
           ->setParameter(8, $this->feedback_name)
-          ->setParameter(9, $this->view_feedback)
+          ->setParameter(9, $this->view_feedback ? 1 : 0, ParameterType::INTEGER)
           ->setParameter(10, $this->id);
         } else {
             // the assessment does not exist. Create it

--- a/src/includes/classes/Assessment.php
+++ b/src/includes/classes/Assessment.php
@@ -206,12 +206,13 @@ class Assessment
         $this->open_date = strtotime($row['open_date']);
         $this->close_date = strtotime($row['close_date']);
         $this->introduction = $row['introduction'];
-        $this->allow_feedback = ($row['allow_feedback']==1);
-        $this->assessment_type = ($row['assessment_type']); //==1);
-        $this->allow_assessment_feedback = ($row['student_feedback']);
-        $this->email_opening = ($row['email_opening']);
-        $this->email_closing = ($row['email_closing']);
-        $this->feedback_name = ($row['feedback_name']);
+        $this->allow_feedback = $row['allow_feedback'] == 1;
+        $this->assessment_type = $row['assessment_type'];;
+        $this->allow_assessment_feedback = $row['student_feedback'];
+        $this->email_opening = $row['email_opening'];
+        $this->email_closing = $row['email_closing'];
+        $this->feedback_name = $row['feedback_name'];
+        $this->view_feedback = $row['view_feedback'];
 
         return true;
     }

--- a/src/includes/classes/Assessment.php
+++ b/src/includes/classes/Assessment.php
@@ -309,7 +309,7 @@ class Assessment
           ->setParameter(7, date(MYSQL_DATETIME_FORMAT, $this->close_date))
           ->setParameter(8, $this->introduction)
           ->setParameter(9, $this->feedback_name)
-          ->setParameter(10, $this->view_feedback, ParameterType::INTEGER);
+          ->setParameter(10, $this->view_feedback ? 1 : 0, ParameterType::INTEGER);
         }
 
         $queryBuilder->execute();

--- a/src/includes/classes/Assessment.php
+++ b/src/includes/classes/Assessment.php
@@ -40,6 +40,8 @@ class Assessment
 
     public $email_closing = false;
 
+    public $view_feedback;
+
     // Private Vars
     private DAO $_DAO;
 
@@ -257,6 +259,7 @@ class Assessment
           ->set('feedback_name', '?')
           ->set('feedback_length', 0)
           ->set('feedback_optional', 0)
+          ->set('view_feedback', '?')
           ->where('assessment_id = ?')
           ->setParameter(0, $this->name)
           ->setParameter(1, $this->module_id, ParameterType::INTEGER)
@@ -267,7 +270,8 @@ class Assessment
           ->setParameter(6, date(MYSQL_DATETIME_FORMAT, $this->close_date))
           ->setParameter(7, $this->introduction)
           ->setParameter(8, $this->feedback_name)
-          ->setParameter(9, $this->id);
+          ->setParameter(9, $this->view_feedback)
+          ->setParameter(10, $this->id);
         } else {
             // the assessment does not exist. Create it
             $queryBuilder
@@ -292,6 +296,7 @@ class Assessment
                  'feedback_name' => '?',
                  'feedback_length' => 0,
                  'feedback_optional' => 0,
+                 'view_feedback' => '?',
               ]
           )
           ->setParameter(0, $this->id)
@@ -303,7 +308,8 @@ class Assessment
           ->setParameter(6, date(MYSQL_DATETIME_FORMAT, $this->close_date))
           ->setParameter(7, date(MYSQL_DATETIME_FORMAT, $this->close_date))
           ->setParameter(8, $this->introduction)
-          ->setParameter(9, $this->feedback_name);
+          ->setParameter(9, $this->feedback_name)
+          ->setParameter(10, $this->view_feedback, ParameterType::INTEGER);
         }
 
         $queryBuilder->execute();

--- a/src/includes/classes/FormRenderer.php
+++ b/src/includes/classes/FormRenderer.php
@@ -23,6 +23,8 @@ class FormRenderer
 
     public $assessment_feedback_title;
 
+    public $view_feedback = false;
+
     // Private Vars
     private $_form;
 
@@ -317,6 +319,13 @@ class FormRenderer
         <div class="question">
         <p><b><?php echo $this->assessment_feedback_title; ?></b></p>
           <p>This section of the assessment is for you to provide general feedback and/or justification of the <?php echo APP__MARK_TEXT; ?> you have awarded in the section above.</p>
+          <?php if ($this->view_feedback === true) : ?>
+          <div class="warning_box">
+              Please note that for this assessment, your peers will be able to see the justifications you have provided.
+              All comments will be reviewed by academic staff before being released. To maintain anonymity, please avoid
+              using any identifying information in your comments.
+          </div>
+          <?php endif; ?>
           <table class="question_grid" >
 <?php
           //now we know that the assessment feedback is allowed by the system we need to find out if the tutor has set feedback

--- a/src/install/upgrades/20220708.sql
+++ b/src/install/upgrades/20220708.sql
@@ -1,4 +1,4 @@
--- also made a change to the assessments table which will need to be included here
+ALTER TABLE `pa2_assessment` ADD COLUMN view_feedback TINYINT NOT NULL DEFAULT 0 AFTER allow_feedback;
 ALTER TABLE `pa2_user_justification` ADD CONSTRAINT `unique_user_justification` UNIQUE KEY(`assessment_id`, `group_id`, `user_id`, `marked_user_id`);
 ALTER TABLE `pa2_user_justification` DROP PRIMARY KEY;
 ALTER TABLE `pa2_user_justification` ADD COLUMN `id` INT AUTO_INCREMENT PRIMARY KEY FIRST;

--- a/src/install/upgrades/20220708.sql
+++ b/src/install/upgrades/20220708.sql
@@ -18,10 +18,8 @@ CREATE TABLE `pa2_user_justification_publish_date` (
 CREATE TABLE `pa2_user_justification_report` (
     user_justification_report_id VARCHAR(255) NOT NULL,
     assessment_id CHAR(36) NOT NULL,
-    group_id CHAR(36) NOT NULL,
     user_id INT(10) UNSIGNED NOT NULL,
     PRIMARY KEY (user_justification_report_id),
     FOREIGN KEY (assessment_id) REFERENCES pa2_assessment(assessment_id),
-    FOREIGN KEY (group_id) REFERENCES pa2_user_group(group_id),
     FOREIGN KEY (user_id) REFERENCES pa2_user(user_id)
 );

--- a/src/install/upgrades/20220708.sql
+++ b/src/install/upgrades/20220708.sql
@@ -1,0 +1,27 @@
+-- also made a change to the assessments table which will need to be included here
+ALTER TABLE `pa2_user_justification` ADD CONSTRAINT `unique_user_justification` UNIQUE KEY(`assessment_id`, `group_id`, `user_id`, `marked_user_id`);
+ALTER TABLE `pa2_user_justification` DROP PRIMARY KEY;
+ALTER TABLE `pa2_user_justification` ADD COLUMN `id` INT AUTO_INCREMENT PRIMARY KEY FIRST;
+
+CREATE TABLE `pa2_moderated_user_justification` (
+    user_justification_id INT UNSIGNED NOT NULL,
+    moderated_comment TEXT NOT NULL,
+    CONSTRAINT pk_user_justification_id PRIMARY KEY (user_justification_id)
+);
+
+CREATE TABLE `pa2_user_justification_publish_date` (
+    assessment_id CHAR(36) NOT NULL,
+    publish_date DATETIME NOT NULL,
+    FOREIGN KEY (assessment_id) REFERENCES pa2_assessment(assessment_id)
+);
+
+CREATE TABLE `pa2_user_justification_report` (
+    user_justification_report_id VARCHAR(255) NOT NULL,
+    assessment_id CHAR(36) NOT NULL,
+    group_id CHAR(36) NOT NULL,
+    user_id INT(10) UNSIGNED NOT NULL,
+    PRIMARY KEY (user_justification_report_id),
+    FOREIGN KEY (assessment_id) REFERENCES pa2_assessment(assessment_id),
+    FOREIGN KEY (group_id) REFERENCES pa2_user_group(group_id),
+    FOREIGN KEY (user_id) REFERENCES pa2_user(user_id)
+);

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Report showing justification for peer marks
+ *
+ * @copyright Loughborough University
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL version 3
+ *
+ * @link https://github.com/webpa/webpa
+ */
+
+require_once '../../../includes/inc_global.php';
+
+use Doctrine\DBAL\ParameterType;
+use WebPA\includes\functions\Common;
+
+$report_hash = Common::fetch_GET('r');
+
+$userAssessmentQuery =
+    'SELECT             uj.justification_text, u.forename ' .
+    'FROM               ' . APP__DB_TABLE_PREFIX . 'user_justification_report ujr ' .
+    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
+    'ON                 ujr.assessment_id = uj.assessment_id ' .
+    'AND                ujr.user_id = uj.marked_user_id ' .
+    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user u ' .
+    'ON                 u.user_id = ujr.user_id ' .
+    'WHERE              ujr.user_justification_report_id = ?';
+
+$comments = $DB
+    ->getConnection()
+    ->fetchAllAssociative($userAssessmentQuery, [$report_hash], [ParameterType::STRING]);
+
+// Begin page
+
+$UI->page_title = APP__NAME . ' peer comments';
+$UI->head();
+?>
+<style>
+    #side_bar {
+        display: none;
+    }
+
+    #main {
+        margin: 0;
+    }
+
+    table.grid th { padding: 8px; }
+    table.grid td { padding: 8px; text-align: center; }
+    table.grid td.important { background-color: #eec; }
+</style>
+<?php
+$UI->body();
+$UI->content_start();
+?>
+
+<h2>Peer Feedback Justification Comments</h2>
+
+<table class="grid">
+    <tr>
+        <th>#</th>
+        <th>Comment</th>
+    </tr>
+    <?php foreach ($comments as $index => $comment) : ?>
+    <tr>
+        <td><?= $index + 1 ?></td>
+        <td><?= $comment['justification_text'] ?></td>
+    </tr>
+
+    <?php endforeach; ?>
+</table>
+
+<?php
+
+$UI->content_end();

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -28,7 +28,7 @@ if (empty($report_hash)) {
         'ON                 ujr.assessment_id = uj.assessment_id ' .
         'AND                ujr.user_id = uj.marked_user_id ' .
         'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'moderated_user_justification muj ' .
-        'ON                 mdj.user_justification_id = uj.id ' .
+        'ON                 muj.user_justification_id = uj.id ' .
         'WHERE              ujr.user_justification_report_id = ?';
 
     try {

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -18,13 +18,11 @@ $report_hash = Common::fetch_GET('r');
 $errors = null;
 
 $userAssessmentQuery =
-    'SELECT             uj.justification_text, u.forename ' .
+    'SELECT             uj.justification_text ' .
     'FROM               ' . APP__DB_TABLE_PREFIX . 'user_justification_report ujr ' .
     'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
     'ON                 ujr.assessment_id = uj.assessment_id ' .
     'AND                ujr.user_id = uj.marked_user_id ' .
-    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user u ' .
-    'ON                 u.user_id = ujr.user_id ' .
     'WHERE              ujr.user_justification_report_id = ?';
 
 try {

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -22,11 +22,13 @@ if (empty($report_hash)) {
     $errors[] = 'No report ID has been provided';
 } else {
     $userAssessmentQuery =
-        'SELECT             uj.justification_text ' .
+        'SELECT             uj.justification_text, muj.moderated_comment ' .
         'FROM               ' . APP__DB_TABLE_PREFIX . 'user_justification_report ujr ' .
         'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
         'ON                 ujr.assessment_id = uj.assessment_id ' .
         'AND                ujr.user_id = uj.marked_user_id ' .
+        'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'moderated_user_justification muj ' .
+        'ON                 mdj.user_justification_id = uj.id ' .
         'WHERE              ujr.user_justification_report_id = ?';
 
     try {
@@ -82,7 +84,7 @@ $UI->draw_boxed_list(
         <?php foreach ($comments as $index => $comment) : ?>
         <tr>
             <td><?= $index + 1 ?></td>
-            <td><?= $comment['justification_text'] ?></td>
+            <td><?= !empty($comment['moderated_comment']) ? $comment['moderated_comment'] : $comment['justification_text']; ?></td>
         </tr>
         <?php endforeach; ?>
     </table>

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -14,25 +14,30 @@ require_once '../../../includes/inc_global.php';
 use Doctrine\DBAL\ParameterType;
 use WebPA\includes\functions\Common;
 
-$report_hash = Common::fetch_GET('r');
+$comments = null;
 $errors = null;
+$report_hash = Common::fetch_GET('r');
 
-$userAssessmentQuery =
-    'SELECT             uj.justification_text ' .
-    'FROM               ' . APP__DB_TABLE_PREFIX . 'user_justification_report ujr ' .
-    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
-    'ON                 ujr.assessment_id = uj.assessment_id ' .
-    'AND                ujr.user_id = uj.marked_user_id ' .
-    'WHERE              ujr.user_justification_report_id = ?';
+if (empty($report_hash)) {
+    $errors[] = 'No report ID has been provided';
+} else {
+    $userAssessmentQuery =
+        'SELECT             uj.justification_text ' .
+        'FROM               ' . APP__DB_TABLE_PREFIX . 'user_justification_report ujr ' .
+        'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
+        'ON                 ujr.assessment_id = uj.assessment_id ' .
+        'AND                ujr.user_id = uj.marked_user_id ' .
+        'WHERE              ujr.user_justification_report_id = ?';
 
-try {
-    $comments = $DB
-        ->getConnection()
-        ->fetchAllAssociative($userAssessmentQuery, [$report_hash], [ParameterType::STRING]);
-} catch (\Doctrine\DBAL\Exception $e) {
-    error_log('Message: ' . $e->getMessage() . ' - Trace: ' . $e->getTraceAsString());
+    try {
+        $comments = $DB
+            ->getConnection()
+            ->fetchAllAssociative($userAssessmentQuery, [$report_hash], [ParameterType::STRING]);
+    } catch (\Doctrine\DBAL\Exception $e) {
+        error_log('Message: ' . $e->getMessage() . ' - Trace: ' . $e->getTraceAsString());
 
-    $errors[] = 'A problem was encountered when retrieving the report.';
+        $errors[] = 'A problem was encountered when retrieving the report.';
+    }
 }
 
 // Begin page

--- a/src/students/assessments/reports/justification_comments.php
+++ b/src/students/assessments/reports/justification_comments.php
@@ -84,7 +84,6 @@ $UI->draw_boxed_list(
             <td><?= $index + 1 ?></td>
             <td><?= $comment['justification_text'] ?></td>
         </tr>
-
         <?php endforeach; ?>
     </table>
     <?php else : ?>

--- a/src/students/assessments/take/index.php
+++ b/src/students/assessments/take/index.php
@@ -98,6 +98,7 @@ if ($assessment->load($assessment_id)) {
             $form_renderer->set_participants($people);
             $form_renderer->assessment_feedback = $assessment->allow_assessment_feedback;
             $form_renderer->assessment_feedback_title = $assessment->feedback_name;
+            $form_renderer->view_feedback = $assessment->view_feedback === 1;
         }
     }
 } else {

--- a/src/tutors/assessments/create/class_wizardstep_1.php
+++ b/src/tutors/assessments/create/class_wizardstep_1.php
@@ -30,25 +30,10 @@ class WizardStep1
     public function head()
     {
         ?>
-<script language="JavaScript" type="text/javascript">
-<!--
-
+<script>
   function body_onload() {
     document.getElementById('assessment_name').focus();
   }
-
-  function open_close(id) {
-    id = document.getElementById(id);
-
-      if (id.style.display == 'block' || id.style.display == '')
-          id.style.display = 'none';
-      else
-          id.style.display = 'block';
-
-      return;
-  }
-
-//-->
 </script>
 <?php
     }
@@ -149,11 +134,7 @@ class WizardStep1
       </table>
     </div>
 
-    <div style="float:right"><b>Advanced Options</b> <a href="#" onclick="open_close('advanced')"><img src="../../../images/icons/advanced_options.gif" alt="view / hide advanced options"></a>
-    <br/><br/></div>
-    <div id="advanced" style="display:none;" class="advanced_options">
-
-      <h2>notification emails</h2>
+      <h2>Notification Emails</h2>
 
       <p><label>Do you want to email all students when this assessment is created?</label></p>
       <p>This option will send an email to all of the students who are in the groups for this assessment as soon as you click the finish button at the end of the wizard.</p>
@@ -168,7 +149,6 @@ class WizardStep1
           <td valign="top"><label class="small" for="email_no">No, don't email all students.</label></td>
         </tr>
         </table>
-      </div>
 
 <?php
     if (APP__REMINDER_OPENING) {

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -200,7 +200,7 @@ class WizardStep2
                     </div>
                     <div id="view-anonymised-feedback" class="hide">
                         <p>
-                            <b>Would you like students to see anonymised  justifications for feedback from their peers?</b>
+                            <b>Would you like students to see anonymised justifications for feedback from their peers?</b>
                         </p>
                         <p>
                             Usually text based feedback can only be seen by tutors. By selecting this option, students will

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -176,7 +176,6 @@ class WizardStep2
                                 </td>
                             </tr>
                             <tr>
-                                <!-- THIS IS WHERE I NEED TO ADD THE CUSTOM JS -->
                                 <td>
                                     <input type="radio" name="allow_text_input" id="allow_text_input_yes"
                                            value="1" <?php echo ($this->wizard->get_field('allow_student_input')) ? 'checked="checked"' : ''; ?>>

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -36,25 +36,8 @@ class WizardStep2
 
     public function head()
     {
-        ?>
-        <script>
-          function body_onload () {
-          }// /body_onload()
 
-          function open_close (id) {
-            id = document.getElementById(id);
-
-            if (id.style.display == 'block' || id.style.display == '') {
-              id.style.display = 'none';
-            } else {
-              id.style.display = 'block';
-            }
-          }
-        </script>
-        <?php
     }
-
-    // /->head()
 
     public function form()
     {
@@ -124,11 +107,7 @@ class WizardStep2
             //check that the system allows student Justification
             if (APP__ALLOW_TEXT_INPUT) {
                 //provide the academic the option?>
-                <div style="float:right"><b>Advanced Options</b> <a href="#" onclick="open_close('advanced')"><img
-                                src="../../../images/icons/advanced_options.gif" alt="view / hide advanced options"></a>
-                    <br/><br/></div>
-                <div id="advanced" style="display:none;" class="advanced_options">
-                    <h2>Feedback / justification</h2>
+                    <h2>Feedback / Justification</h2>
                     <p><label>Do you want students to be able to view feedback for this assesment?</label></p>
                     <p>Once an assessment is completed, students can login and view feedback related to their
                         performance within the group for this assessment. The feedback simply shows whether they were
@@ -197,7 +176,6 @@ class WizardStep2
                             </tr>
                         </table>
                     </div>
-                </div>
                 <?php
             }
         }

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -36,7 +36,28 @@ class WizardStep2
 
     public function head()
     {
+        ?>
+        <script>
+          function body_onload() {
+            const toggleHide = function (e) {
+              const viewAnonymisedFeedback = document.getElementById('view-anonymised-feedback');
 
+              if (e.target.id === 'allow_text_input_yes') {
+                viewAnonymisedFeedback.classList.remove('hide');
+              } else {
+                viewAnonymisedFeedback.classList.add('hide');
+              }
+            };
+
+            // Get the radiobutton to confirm you want justified feedback
+            const radioButtons = document.getElementsByName('allow_text_input');
+
+            for (radioButton of radioButtons) {
+              radioButton.onchange = toggleHide;
+            }
+          }
+        </script>
+        <?php
     }
 
     public function form()
@@ -108,11 +129,15 @@ class WizardStep2
             if (APP__ALLOW_TEXT_INPUT) {
                 //provide the academic the option?>
                     <h2>Feedback / Justification</h2>
-                    <p><label>Do you want students to be able to view feedback for this assesment?</label></p>
-                    <p>Once an assessment is completed, students can login and view feedback related to their
+                    <p>
+                        <b>Do you want students to be able to view relative performance feedback?</b>
+                    </p>
+                    <p>
+                        Once an assessment is completed, students can login and view feedback related to their
                         performance within the group for this assessment. The feedback simply shows whether they were
                         rated as performing below, at, or above average for each criterion within the group for this
-                        assessment.</p>
+                        assessment.
+                    </p>
                     <div class="form_section">
                         <table class="form" cellpadding="2" cellspacing="2">
                             <tr>
@@ -131,50 +156,69 @@ class WizardStep2
                             </tr>
                         </table>
                     </div>
-                    <p><label>Would you like students to provide text based feedback?</label></p>
-                    <p>If you would like students to provide textual information as either feedback or justification on
-                        the scores that they have assigned in the assessment, then you will need to select the option
-                        from below. The default option is to provide <b>no</b> mechanism for students to comment.</p>
+                    <p>
+                        <b>Would you like students to provide feedback to justify their scoring?</b>
+                    </p>
+                    <p>
+                        If you would like students to provide feedback or justification on the scores that they have
+                        assigned in the assessment, then you will need to select the option from below. The default
+                        option is to provide <strong>no</strong> mechanism for students to comment.
+                    </p>
                     <div class="form_section">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
-                                <td><label class="small" for="feedback_name">Title </label></td>
-                                <td><input type="text" name="feedback_name" id="feedback_name" maxlength="100" size="40"
-                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>"></td>
+                                <td>
+                                    <label class="small" for="feedback_name">Feedback Form Title </label>
+                                </td>
+                                <td>
+                                    <input type="text" name="feedback_name" id="feedback_name" maxlength="100" size="40"
+                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>">
+                                </td>
                             </tr>
                             <tr>
                                 <!-- THIS IS WHERE I NEED TO ADD THE CUSTOM JS -->
-                                <td><input type="radio" name="allow_text_input" id="allow_text_input_yes"
+                                <td>
+                                    <input type="radio" name="allow_text_input" id="allow_text_input_yes"
                                            value="1" <?php echo ($this->wizard->get_field('allow_student_input')) ? 'checked="checked"' : ''; ?>>
                                 </td>
-                                <td><label class="small" for="allow_text_input_yes"><b>Yes</b>, allow students to
-                                        comment.</label></td>
+                                <td>
+                                    <label class="small" for="allow_text_input_yes"><b>Yes</b>, allow students to
+                                        comment.</label>
+                                </td>
                             </tr>
                             <tr>
-                                <td><input type="radio" name="allow_text_input" id="allow_text_input_no"
+                                <td>
+                                    <input type="radio" name="allow_text_input" id="allow_text_input_no"
                                            value="0" <?php echo (!$this->wizard->get_field('allow_student_input')) ? 'checked="checked"' : ''; ?>>
                                 </td>
-                                <td><label class="small" for="allow_text_input_no"><b>No</b>, don't allow students to
-                                        comment.</label></td>
+                                <td>
+                                    <label class="small" for="allow_text_input_no">
+                                        <b>No</b>, don't allow students to comment.
+                                    </label>
+                                </td>
                             </tr>
                         </table>
                     </div>
-                    <p><label>Would you like students to see anonymised, text based feedback?</label></p>
-                    <p>
-                        Usually text based feedback can only be seen by tutors. By selecting this option, students will
-                        be able to see text based feedback that has been reviewed and anonymised.
-                    </p>
-                    <div class="form_section">
-                        <table cellpadding="2" cellspacing="2">
-                            <tr>
-                                <th valign="top" style="padding-top: 2px; vertical-align: top;">
-                                    <label class="small" for="view_feedback">View&nbsp;feedback</label>
-                                </th>
-                                <td width="100%">
-                                    <input type="checkbox" id="view_feedback" name="view_feedback" value="view_feedback">
-                                </td>
-                            </tr>
-                        </table>
+                    <div id="view-anonymised-feedback" class="hide">
+                        <p>
+                            <b>Would you like students to see anonymised  justifications for feedback from their peers?</b>
+                        </p>
+                        <p>
+                            Usually text based feedback can only be seen by tutors. By selecting this option, students will
+                            be able to see feedback from their peers that has been reviewed and anonymised.
+                        </p>
+                        <div class="form_section">
+                            <table cellpadding="2" cellspacing="2">
+                                <tr>
+                                    <th valign="top" style="padding-top: 2px; vertical-align: top;">
+                                        <label class="small" for="view_feedback">Show justification</label>
+                                    </th>
+                                    <td width="100%">
+                                        <input type="checkbox" id="view_feedback" name="view_feedback" value="view_feedback">
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
                     </div>
                 <?php
             }

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -37,24 +37,19 @@ class WizardStep2
     public function head()
     {
         ?>
-        <script language="JavaScript" type="text/javascript">
-          <!--
-
+        <script>
           function body_onload () {
           }// /body_onload()
 
           function open_close (id) {
-            id = document.getElementById(id)
+            id = document.getElementById(id);
 
-            if (id.style.display == 'block' || id.style.display == '')
-              id.style.display = 'none'
-            else
-              id.style.display = 'block'
-
-            return
+            if (id.style.display == 'block' || id.style.display == '') {
+              id.style.display = 'none';
+            } else {
+              id.style.display = 'block';
+            }
           }
-
-          //-->
         </script>
         <?php
     }
@@ -145,19 +140,19 @@ class WizardStep2
                                 <td><input type="radio" name="allow_feedback" id="allow_feedback_yes"
                                            value="1" <?php echo ($allow_feedback) ? 'checked="checked"' : ''; ?> />
                                 </td>
-                                <td valign="top"><label class="small" for="allow_feedback_yes">Yes, allow students to
+                                <td valign="top"><label class="small" for="allow_feedback_yes"><strong>Yes</strong>, allow students to
                                         view feedback.</label></td>
                             </tr>
                             <tr>
                                 <td><input type="radio" name="allow_feedback" id="allow_feedback_no"
                                            value="0" <?php echo (!$allow_feedback) ? 'checked="checked"' : ''; ?> />
                                 </td>
-                                <td valign="top"><label class="small" for="allow_feedback_no">No, there is no feedback
+                                <td valign="top"><label class="small" for="allow_feedback_no"><strong>No</strong>, there is no feedback
                                         for this assessment.</label></td>
                             </tr>
                         </table>
                     </div>
-                    <p><label>Would you like students to enter feedback textually?</label></p>
+                    <p><label>Would you like students to provide text based feedback?</label></p>
                     <p>If you would like students to provide textual information as either feedback or justification on
                         the scores that they have assigned in the assessment, then you will need to select the option
                         from below. The default option is to provide <b>no</b> mechanism for students to comment.</p>
@@ -169,6 +164,7 @@ class WizardStep2
                                            value="<?php echo $this->wizard->get_field('feedback_name'); ?>"></td>
                             </tr>
                             <tr>
+                                <!-- THIS IS WHERE I NEED TO ADD THE CUSTOM JS -->
                                 <td><input type="radio" name="allow_text_input" id="allow_text_input_yes"
                                            value="1" <?php echo ($this->wizard->get_field('allow_student_input')) ? 'checked="checked"' : ''; ?>>
                                 </td>
@@ -181,6 +177,23 @@ class WizardStep2
                                 </td>
                                 <td><label class="small" for="allow_text_input_no"><b>No</b>, don't allow students to
                                         comment.</label></td>
+                            </tr>
+                        </table>
+                    </div>
+                    <p><label>Would you like students to see anonymised, text based feedback?</label></p>
+                    <p>
+                        Usually text based feedback can only be seen by tutors. By selecting this option, students will
+                        be able to see text based feedback that has been reviewed and anonymised.
+                    </p>
+                    <div class="form_section">
+                        <table cellpadding="2" cellspacing="2">
+                            <tr>
+                                <th valign="top" style="padding-top: 2px; vertical-align: top;">
+                                    <label class="small" for="view_feedback">View&nbsp;feedback</label>
+                                </th>
+                                <td width="100%">
+                                    <input type="checkbox" id="view_feedback" name="view_feedback" value="view_feedback">
+                                </td>
                             </tr>
                         </table>
                     </div>
@@ -207,6 +220,8 @@ class WizardStep2
         if (APP__ALLOW_TEXT_INPUT) {
             $this->wizard->set_field('allow_student_input', Common::fetch_POST('allow_text_input'));
         }
+
+        $this->wizard->set_field('view_feedback', Common::fetch_POST('view_feedback'));
 
         return $errors;
     }

--- a/src/tutors/assessments/create/class_wizardstep_4.php
+++ b/src/tutors/assessments/create/class_wizardstep_4.php
@@ -31,61 +31,34 @@ class WizardStep4
 
     public function head()
     {
-        ?>
-<script language="JavaScript" type="text/javascript">
-<!--
 
-  function body_onload() {
-  }// /body_onload()
-
-  function open_close(id) {
-    id = document.getElementById(id);
-
-      if (id.style.display == 'block' || id.style.display == '')
-          id.style.display = 'none';
-      else
-          id.style.display = 'block';
-
-      return;
-  }
-
-//-->
-</script>
-<?php
     }
 
     // /->head()
 
     public function form()
     {
-        $assessment_type = $this->wizard->get_field('assessment_type', 1); ?>
+        $assessment_type = $this->wizard->get_field('assessment_type', 0); ?>
     <h2>Assessment Type</h2>
     <div class="form_section">
       <table class="form" cellpadding="2" cellspacing="2">
       <tr>
         <td>
-          <input type="radio" name="assessment_type" value="1" id="both" <?php echo (!$assessment_type)? 'checked="checked"' : ''; ?>>
+          <input type="radio" name="assessment_type" value="1" id="both" <?php echo !$assessment_type ? 'checked="checked"' : ''; ?>>
         </td>
         <td>
           <label class="small" for="both">Self and peer assessment</label>
         </td>
       </tr>
+          <tr>
+              <td>
+                  <input type="radio" name="assessment_type" value="0" id="peer" <?php echo $assessment_type ? 'checked="checked"' : ''; ?>/>
+              </td>
+              <td>
+                  <label class="small" for="peer">Peer assessment only</label>
+              </td>
+          </tr>
       </table>
-      <br/><br/>
-      <div style="float:right"><b>Advanced Options</b> <a href="#" onclick="open_close('advanced')"><img src="../../../images/icons/advanced_options.gif" alt="view / hide advanced options"></a>
-      <br/><br/></div>
-      <div id="advanced" style="display:none;" class="advanced_options">
-      <table class="form" cellpadding="2" cellspacing="2">
-      <tr>
-        <td>
-          <input type="radio" name="assessment_type" value="0" id="peer" <?php echo ($assessment_type)? 'checked="checked"' : ''; ?>/>
-        </td>
-        <td>
-          <label class="small" for="peer">Peer assessment only</label>
-        </td>
-      </tr>
-      </table>
-      </div>
     </div>
 
 <?php

--- a/src/tutors/assessments/create/class_wizardstep_5.php
+++ b/src/tutors/assessments/create/class_wizardstep_5.php
@@ -137,6 +137,14 @@ class WizardStep5
         } ?>
     </div>
 
+    <h2>Feedback</h2>
+
+    <?php if ($this->wizard->get_field('view_feedback') === 'view_feedback') : ?>
+    <p>Students <strong>can</strong> see anonymised feedback justification</p>
+    <?php else : ?>
+    <p>Students <strong>cannot</strong> see anonymised feedback justification</p>
+    <?php endif; ?>
+
     <h2>Groups</h2>
     <div class="form_section">
 <?php

--- a/src/tutors/assessments/create/class_wizardstep_6.php
+++ b/src/tutors/assessments/create/class_wizardstep_6.php
@@ -74,6 +74,7 @@ class WizardStep6
         $assessment->email_opening = $this->wizard->get_field('email_opening') == 1;
         $assessment->email_closing = $this->wizard->get_field('email_closing') == 1;
         $assessment->feedback_name = $this->wizard->get_field('feedback_name');
+        $assessment->view_feedback = $this->wizard->get_field('view_feedback') === 'view_feedback' ? 1 : 0;
 
         // Set the form to use for assessment
         $form = new Form($DB);

--- a/src/tutors/assessments/inc_list_closed.php
+++ b/src/tutors/assessments/inc_list_closed.php
@@ -60,6 +60,17 @@ $assessments = $DB->getConnection()->fetchAllAssociative(
         ]
 );
 
+/**
+ * Map assessment IDs to comment publication dates. This is neededed because the SimpleObjectIterator used on this page
+ * only deals with fields in the assessment table. The comment publication date is stored in a different table so is
+ * not included in the Assessment class
+ */
+$commentsPublicationDateMap = [];
+
+foreach ($assessments as $assessment) {
+    $commentsPublicationDateMap[$assessment['assessment_id']] = $assessment['comments_publish_date'];
+}
+
 if (!$assessments) {
     ?>
   <p>You do not have any assessments in this category.</p>
@@ -79,6 +90,8 @@ if (!$assessments) {
 
         for ($assessment_iterator->reset(); $assessment_iterator->is_valid(); $assessment_iterator->next()) {
             $assessment =& $assessment_iterator->current();
+
+            $commentPublicationDate = $commentsPublicationDateMap[$assessment->id];
 
             $num_responses = (array_key_exists($assessment->id, $responses)) ? $responses[$assessment->id] : 0 ;
             $num_members =  (array_key_exists($assessment->id, $members)) ? $members[$assessment->id] : 0 ;
@@ -106,7 +119,7 @@ if (!$assessments) {
             <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
             <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
             <a href="<?= $mark_url ?>" title="New marksheet" aria-label="New marksheet"><i data-feather="file-text" aria-hidden="true"></i></a>
-            <?php if (isset($assessment->student_feedback) && $assessment->comments_publish_date === null) : ?>
+            <?php if ($assessment->view_feedback === 1 && $commentPublicationDate === null) : ?>
             <a href="<?= $review_justifications_url ?>" title="Review justification comments" aria-label="Review justification comments"><i data-feather="message-circle" aria-hidden="true"></i></a>
             <?php endif; ?>
         </td>

--- a/src/tutors/assessments/inc_list_closed.php
+++ b/src/tutors/assessments/inc_list_closed.php
@@ -99,12 +99,12 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?= $edit_url ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?= $email_url ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?= $responded_url ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?= $groupmark_url ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
-          <a href="<?= $mark_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="New mark sheet" /></a>
-          <a href="<?= $review_justifications_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="Review justifications" /></a>
+            <a href="<?= $edit_url ?>" title="Edit" aria-label="Edit"><i data-feather="edit-2" aria-hidden="true"></i></a>
+            <a href="<?= $email_url ?>" title="Email students" aria-label="Email students"><i data-feather="mail" aria-hidden="true"></i></a>
+            <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
+            <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
+            <a href="<?= $mark_url ?>" title="New marksheet" aria-label="New marksheet"><i data-feather="file-text" aria-hidden="true"></i></a>
+            <a href="<?= $review_justifications_url ?>" title="Review justification comments" aria-label="Review justification comments"><i data-feather="message-circle" aria-hidden="true"></i></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_closed.php
+++ b/src/tutors/assessments/inc_list_closed.php
@@ -31,10 +31,12 @@ use WebPA\includes\classes\SimpleObjectIterator;
 $now = date(MYSQL_DATETIME_FORMAT);
 
 $assessmentsQuery =
-    'SELECT a.* ' .
+    'SELECT a.*, pd.publish_date AS comments_publish_date ' .
     'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
     'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'assessment_marking am ' .
     'ON a.assessment_id = am.assessment_id ' .
+    'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'user_justification_publish_date pd ' .
+    'ON a.assessment_id = pd.assessment_id ' .
     'WHERE a.module_id = ? ' .
     'AND a.open_date >= ? ' .
     'AND a.open_date < ? ' .
@@ -94,7 +96,7 @@ if (!$assessments) {
       <tr>
         <td class="icon" width="24"><img src="../../images/icons/closed_icon.gif" alt="Closed" title="Closed" height="24" width="24" /></td>
         <td class="obj_info">
-          <div class="obj_name"><?php echo $assessment->name; ?></div>
+          <div class="obj_name"><?= $assessment->name; ?></div>
           <div class="obj_info_text">scheduled: <?php echo $assessment->get_date_string('open_date'); ?> &nbsp;-&nbsp; <?php echo $assessment->get_date_string('close_date'); ?></div>
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
@@ -104,7 +106,9 @@ if (!$assessments) {
             <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
             <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
             <a href="<?= $mark_url ?>" title="New marksheet" aria-label="New marksheet"><i data-feather="file-text" aria-hidden="true"></i></a>
+            <?php if (isset($assessment->student_feedback) && $assessment->comments_publish_date === null) : ?>
             <a href="<?= $review_justifications_url ?>" title="Review justification comments" aria-label="Review justification comments"><i data-feather="message-circle" aria-hidden="true"></i></a>
+            <?php endif; ?>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_closed.php
+++ b/src/tutors/assessments/inc_list_closed.php
@@ -86,7 +86,9 @@ if (!$assessments) {
             $email_url = "email/index.php?a={$assessment->id}&{$qs}";
             $responded_url = "students_who_responded.php?a={$assessment->id}&{$qs}";
             $groupmark_url = "marks/set_group_marks.php?a={$assessment->id}&{$qs}";
-            $mark_url = "marks/mark_assessment.php?a={$assessment->id}&{$qs}"; ?>
+            $mark_url = "marks/mark_assessment.php?a={$assessment->id}&{$qs}";
+            $review_justifications_url = "marks/review_justification.php?a={$assessment->id}&{$qs}";
+            ?>
     <div class="obj">
       <table class="obj" cellpadding="2" cellspacing="2">
       <tr>
@@ -97,11 +99,12 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?php echo $edit_url; ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?php echo $email_url; ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?php echo $responded_url; ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?php echo $groupmark_url; ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
-          <a href="<?php echo $mark_url; ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="New mark sheet" /></a>
+          <a href="<?= $edit_url ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
+          <a href="<?= $email_url ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
+          <a href="<?= $responded_url ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
+          <a href="<?= $groupmark_url ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
+          <a href="<?= $mark_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="New mark sheet" /></a>
+          <a href="<?= $review_justifications_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="Review justifications" /></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_marked.php
+++ b/src/tutors/assessments/inc_list_marked.php
@@ -102,6 +102,7 @@ if (!$assessments) {
             $groupmark_url = "marks/set_group_marks.php?a={$assessment->id}&{$qs}";
             $responded_url = "students_who_responded.php?a={$assessment->id}&{$qs}";
             $mark_url = "marks/mark_assessment.php?a={$assessment->id}&{$qs}";
+            $review_justifications_url = "marks/review_justification.php?a={$assessment->id}&{$qs}";
 
             $mark_sheets = $assessment->get_all_marking_params(); ?>
     <div class="obj">
@@ -119,6 +120,7 @@ if (!$assessments) {
           <a href="<?php echo $responded_url; ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
           <a href="<?php echo $groupmark_url; ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
           <a href="<?php echo $mark_url; ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="New mark sheet" /></a>
+          <a href="<?= $review_justifications_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="Review justifications" /></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_marked.php
+++ b/src/tutors/assessments/inc_list_marked.php
@@ -42,10 +42,12 @@ use WebPA\includes\classes\XMLParser;
 $now = date(MYSQL_DATETIME_FORMAT);
 
 $assessmentsQuery =
-    'SELECT DISTINCT a.* ' .
+    'SELECT DISTINCT a.*, pd.publish_date AS comments_publish_date ' .
     'FROM ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
     'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'assessment_marking am ' .
     'ON a.assessment_id = am.assessment_id ' .
+    'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'user_justification_publish_date pd ' .
+    'ON a.assessment_id = pd.assessment_id ' .
     'WHERE a.module_id = ? ' .
     'AND a.open_date >= ? ' .
     'AND a.open_date < ? ' .
@@ -115,12 +117,14 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?php echo $edit_url; ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?php echo $email_url; ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?php echo $responded_url; ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?php echo $groupmark_url; ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
-          <a href="<?php echo $mark_url; ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="New mark sheet" /></a>
-          <a href="<?= $review_justifications_url ?>"><img src="../../images/buttons/mark_sheet.gif" width="16" height="16" alt="Mark Sheet" title="Review justifications" /></a>
+            <a href="<?= $edit_url ?>" title="Edit" aria-label="Edit"><i data-feather="edit-2" aria-hidden="true"></i></a>
+            <a href="<?= $email_url ?>" title="Email students" aria-label="Email students"><i data-feather="mail" aria-hidden="true"></i></a>
+            <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
+            <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
+            <a href="<?= $mark_url ?>" title="New marksheet" aria-label="New marksheet"><i data-feather="file-text" aria-hidden="true"></i></a>
+            <?php if (isset($assessment->student_feedback) && $assessment->comments_publish_date === null) : ?>
+            <a href="<?= $review_justifications_url ?>" title="Review justification comments" aria-label="Review justification comments"><i data-feather="message-circle" aria-hidden="true"></i></a>
+            <?php endif; ?>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_marked.php
+++ b/src/tutors/assessments/inc_list_marked.php
@@ -71,6 +71,18 @@ $assessments = $DB->getConnection()->fetchAllAssociative(
     ]
 );
 
+/**
+ * Map assessment IDs to comment publication dates. This is neededed because the SimpleObjectIterator used on this page
+ * only deals with fields in the assessment table. The comment publication date is stored in a different table so is
+ * not included in the Assessment class
+ */
+$commentsPublicationDateMap = [];
+
+foreach ($assessments as $assessment) {
+    $commentsPublicationDateMap[$assessment['assessment_id']] = $assessment['comments_publish_date'];
+}
+
+
 if (!$assessments) {
     ?>
   <p>You do not have any assessments in this category.</p>
@@ -94,6 +106,8 @@ if (!$assessments) {
         for ($assessment_iterator->reset(); $assessment_iterator->is_valid(); $assessment_iterator->next()) {
             $assessment =& $assessment_iterator->current();
             $assessment->set_db($DB);
+
+            $commentPublicationDate = $commentsPublicationDateMap[$assessment->id];
 
             $num_responses = (array_key_exists($assessment->id, $responses)) ? $responses[$assessment->id] : 0 ;
             $num_members =  (array_key_exists($assessment->id, $members)) ? $members[$assessment->id] : 0 ;
@@ -122,7 +136,7 @@ if (!$assessments) {
             <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
             <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
             <a href="<?= $mark_url ?>" title="New marksheet" aria-label="New marksheet"><i data-feather="file-text" aria-hidden="true"></i></a>
-            <?php if (isset($assessment->student_feedback) && $assessment->comments_publish_date === null) : ?>
+            <?php if ($assessment->view_feedback === 1 && $commentPublicationDate === null) : ?>
             <a href="<?= $review_justifications_url ?>" title="Review justification comments" aria-label="Review justification comments"><i data-feather="message-circle" aria-hidden="true"></i></a>
             <?php endif; ?>
         </td>

--- a/src/tutors/assessments/inc_list_open.php
+++ b/src/tutors/assessments/inc_list_open.php
@@ -94,11 +94,11 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?php echo $edit_url; ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?php echo $email_url; ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?php echo $responded_url; ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?php echo $groupmark_url; ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
-          <a href="<?php echo $delete_marks_url; ?>"><img src="../../images/icons/group_delete.png" width="16" height="16" alt="Delete individual marks" title="Delete individual marks" /></a>
+          <a href="<?= $edit_url ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
+          <a href="<?= $email_url ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
+          <a href="<?= $responded_url ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
+          <a href="<?= $groupmark_url ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
+          <a href="<?= $delete_marks_url ?>"><img src="../../images/icons/group_delete.png" width="16" height="16" alt="Delete individual marks" title="Delete individual marks" /></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_open.php
+++ b/src/tutors/assessments/inc_list_open.php
@@ -94,11 +94,11 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?= $edit_url ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?= $email_url ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?= $responded_url ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?= $groupmark_url ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
-          <a href="<?= $delete_marks_url ?>"><img src="../../images/icons/group_delete.png" width="16" height="16" alt="Delete individual marks" title="Delete individual marks" /></a>
+            <a href="<?= $edit_url ?>" title="Edit" aria-label="Edit"><i data-feather="edit-2" aria-hidden="true"></i></a>
+            <a href="<?= $email_url ?>" title="Email students" aria-label="Email students"><i data-feather="mail" aria-hidden="true"></i></a>
+            <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
+            <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
+            <a href="<?= $delete_marks_url ?>" title="Delete individual marks" aria-label="Delete individual marks"><i data-feather="user-x" aria-hidden="true"></i></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/inc_list_pending.php
+++ b/src/tutors/assessments/inc_list_pending.php
@@ -94,10 +94,10 @@ if (!$assessments) {
           <div class="obj_info_text">student responses: <?php echo "$num_responses / $num_members $completed_msg"; ?></div>
         </td>
         <td class="buttons">
-          <a href="<?php echo $edit_url; ?>"><img src="../../images/buttons/edit.gif" width="16" height="16" alt="Edit" title="Edit assessment" /></a>
-          <a href="<?php echo $email_url; ?>"><img src="../../images/buttons/email.gif" width="16" height="16" alt="Email" title="Email students" /></a>
-          <a href="<?php echo $responded_url; ?>"><img src="../../images/buttons/students_responded.gif" width="16" height="16" alt="Students responded" title="Check which students have responded" /></a>
-          <a href="<?php echo $groupmark_url; ?>"><img src="../../images/buttons/group_marks.gif" width="16" height="16" alt="Group Marks" title="Set group marks" /></a>
+            <a href="<?= $edit_url ?>" title="Edit" aria-label="Edit"><i data-feather="edit-2" aria-hidden="true"></i></a>
+            <a href="<?= $email_url ?>" title="Email students" aria-label="Email students"><i data-feather="mail" aria-hidden="true"></i></a>
+            <a href="<?= $responded_url ?>" title="Which students responded" aria-label="Which students responded"><i data-feather="user-check" aria-hidden="true"></i></a>
+            <a href="<?= $groupmark_url ?>" title="Set group marks" aria-label="Set group marks"><i data-feather="check" aria-hidden="true"></i></a>
         </td>
       </tr>
       </table>

--- a/src/tutors/assessments/index.php
+++ b/src/tutors/assessments/index.php
@@ -89,15 +89,14 @@ $change_onclick = ' onclick="change_academic_year()"';
 ?>
 <script src="https://unpkg.com/feather-icons"></script>
 <script>
-<!--
-
   function change_academic_year() {
     year_sbox = document.getElementById('academic_year');
     chosen_year = year_sbox.options[year_sbox.selectedIndex].value;
-    if (chosen_year) { window.location.href='<?php echo $page_url ."?tab={$tab}&y="; ?>'+chosen_year; }
-  }
 
-//-->
+    if (chosen_year) {
+        window.location.href='<?= $page_url ."?tab={$tab}&y="; ?>' + chosen_year;
+    }
+  }
 </script>
 <?php
 $UI->body();

--- a/src/tutors/assessments/index.php
+++ b/src/tutors/assessments/index.php
@@ -87,7 +87,8 @@ $UI->set_page_bar_button('Create Assessments', '../../../images/buttons/button_a
 $UI->head();
 $change_onclick = ' onclick="change_academic_year()"';
 ?>
-<script language="JavaScript" type="text/javascript">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>
 <!--
 
   function change_academic_year() {
@@ -154,7 +155,10 @@ include_once $include_page;
 
   </form>
 </div>
-
+<script>
+    // insert feather icon sets
+    feather.replace({color: 'black', width: '20px', height: '20px'});
+</script>
 <?php
 
 $UI->content_end();

--- a/src/tutors/assessments/marks/edit_comment.php
+++ b/src/tutors/assessments/marks/edit_comment.php
@@ -5,7 +5,7 @@ require_once '../../../includes/inc_global.php';
 use WebPA\includes\functions\Common;
 
 if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
-    header('Location:' . APP__WWW . '/logout.php?msg=denied');
+    http_response_code(401);
 
     exit;
 }

--- a/src/tutors/assessments/marks/edit_comment.php
+++ b/src/tutors/assessments/marks/edit_comment.php
@@ -23,11 +23,9 @@ try {
     $stmt->bindValue(2, Common::fetch_POST('comment'));
     $stmt->bindValue(3, Common::fetch_POST('comment'));
 
-    $response = $stmt->execute();
+    $stmt->execute();
 } catch (\Doctrine\DBAL\Exception $ex) {
     http_response_code(500);
 }
 
-
-// Return the response
-die('<pre>' . print_r($response, true) . '</pre>');
+http_response_code(200);

--- a/src/tutors/assessments/marks/edit_comment.php
+++ b/src/tutors/assessments/marks/edit_comment.php
@@ -1,0 +1,35 @@
+<?php
+
+// Validate the request?
+
+require_once '../../../includes/inc_global.php';
+
+use WebPA\includes\functions\Common;
+
+if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
+    header('Location:' . APP__WWW . '/logout.php?msg=denied');
+
+    exit;
+}
+
+$dbConn = $DB->getConnection();
+
+$sql = 'INSERT INTO ' . APP__DB_TABLE_PREFIX . 'moderated_user_justification VALUES '
+     . '(?, ?) '
+     . 'ON DUPLICATE KEY UPDATE moderated_comment = ?';
+
+try {
+    $stmt = $dbConn->prepare($sql);
+
+    $stmt->bindValue(1, (int) $_POST['comment-id'], \Doctrine\DBAL\ParameterType::INTEGER);
+    $stmt->bindValue(2, $_POST['comment']);
+    $stmt->bindValue(3, $_POST['comment']);
+
+    $response = $stmt->execute();
+} catch (\Doctrine\DBAL\Exception $ex) {
+    http_response_code(500);
+}
+
+
+// Return the response
+die('<pre>' . print_r($response, true) . '</pre>');

--- a/src/tutors/assessments/marks/edit_comment.php
+++ b/src/tutors/assessments/marks/edit_comment.php
@@ -1,7 +1,5 @@
 <?php
 
-// Validate the request?
-
 require_once '../../../includes/inc_global.php';
 
 use WebPA\includes\functions\Common;
@@ -21,9 +19,9 @@ $sql = 'INSERT INTO ' . APP__DB_TABLE_PREFIX . 'moderated_user_justification VAL
 try {
     $stmt = $dbConn->prepare($sql);
 
-    $stmt->bindValue(1, (int) $_POST['comment-id'], \Doctrine\DBAL\ParameterType::INTEGER);
-    $stmt->bindValue(2, $_POST['comment']);
-    $stmt->bindValue(3, $_POST['comment']);
+    $stmt->bindValue(1, (int) Common::fetch_POST('comment-id'), \Doctrine\DBAL\ParameterType::INTEGER);
+    $stmt->bindValue(2, Common::fetch_POST('comment'));
+    $stmt->bindValue(3, Common::fetch_POST('comment'));
 
     $response = $stmt->execute();
 } catch (\Doctrine\DBAL\Exception $ex) {

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -24,7 +24,7 @@ if (empty($assessmentId)) {
 
 // Get every user in the assessment
 $userQuery =
-    'SELECT             a.assessment_id, ugm.user_id, u.email ' .
+    'SELECT             a.assessment_id, a.assessment_name, ugm.user_id, u.forename, u.email ' .
     'FROM               ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
     'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_group ug ' .
     'ON                 ug.collection_id = a.collection_id ' .
@@ -58,14 +58,15 @@ foreach ($assessmentUsers as $user) {
 
 
     $body =
-        "Dear Andrew, \n\n" .
+        "Dear " . $user['forename'] . ", \n\n" .
         "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
-        "Justification comments </a> for the marks you received from your peers for assessment X are now available " .
-        "for you to view, \n\n" .
+        "Justification comments </a> for the marks you received from your peers for assessment '" .
+        $user['assessment_name'] ."' are now available for you to view, \n\n" .
         "Many thanks,\n" .
         "WebPA";
 
-    $email->set_to( 'andrew.millington@ed.ac.uk'/* $user['email'] */);
+    $email->set_to($user['email']);
+    $email->set_bcc(['christopher.mckenzie@ed.ac.uk', 'k.lyszkiewicz@ed.ac.uk', 'vanessa.mather@ed.ac.uk']);
     $email->set_from(APP__EMAIL_NO_REPLY);
     $email->set_subject('WebPA - Peer Feedback Comments Available');
     $email->set_body("You know it's just the same as it was $hash");

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -69,7 +69,7 @@ foreach ($assessmentUsers as $user) {
     $email->set_bcc(['christopher.mckenzie@ed.ac.uk', 'k.lyszkiewicz@ed.ac.uk', 'vanessa.mather@ed.ac.uk']);
     $email->set_from(APP__EMAIL_NO_REPLY);
     $email->set_subject('WebPA - Peer Feedback Comments Available');
-    $email->set_body("You know it's just the same as it was $hash");
+    $email->set_body($body);
     $email->send();
 }
 

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -30,7 +30,7 @@ if (empty($assessmentId)) {
     $errors[] = 'No assessment ID provided.';
 }
 
-// Get every user in the assessment
+// Get every user in the assessment that has at least one comment associated with them
 $userQuery =
     'SELECT             a.assessment_id, a.assessment_name, ugm.user_id, u.forename, u.email ' .
     'FROM               ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
@@ -40,64 +40,65 @@ $userQuery =
     'ON                 ugm.group_id = ug.group_id ' .
     'LEFT JOIN          '. APP__DB_TABLE_PREFIX . 'user u ' .
     'ON                 u.user_id = ugm.user_id ' .
-    'WHERE              a.assessment_id = ?';
+    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
+    'ON                 a.assessment_id = uj.assessment_id ' .
+    'AND                ugm.group_id = uj.group_id ' .
+    'AND                uj.user_id = u.user_id ' .
+    'WHERE              a.assessment_id = ? ' .
+    'AND                uj.justification_text IS NOT NULL ' .
+    'GROUP BY           a.assessment_id, a.assessment_name, ugm.user_id, u.forename, u.email';
 
 try {
     $assessmentUsers = $DB
         ->getConnection()
         ->fetchAllAssociative($userQuery, [$assessmentId], [ParameterType::STRING]);
+
+    foreach ($assessmentUsers as $user) {
+        $hash = hash('sha256', $user['assessment_id'] . $user['user_id'] . random_int(0, 1000000));
+
+        $logReportIdQuery =
+            'INSERT INTO             ' . APP__DB_TABLE_PREFIX . 'user_justification_report ' .
+            'VALUES (?, ?, ?)';
+
+        $stmt = $DB->getConnection()->prepare($logReportIdQuery);
+
+        $stmt->bindValue(1, $hash);
+        $stmt->bindValue(2, $user['assessment_id']);
+        $stmt->bindValue(3, $user['user_id'], ParameterType::INTEGER);
+
+        $stmt->execute();
+
+        $email = new Email();
+
+        $body =
+            "Dear " . $user['forename'] . ", \n\n" .
+            "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
+            "Justification comments </a> for the marks you received from your peers for assessment '" .
+            $user['assessment_name'] ."' are now available for you to view, \n\n" .
+            "Many thanks,\n" .
+            "WebPA";
+
+        $email->set_to($user['email']);
+        $email->set_bcc(['christopher.mckenzie@ed.ac.uk', 'k.lyszkiewicz@ed.ac.uk', 'vanessa.mather@ed.ac.uk']);
+        $email->set_from(APP__EMAIL_NO_REPLY);
+        $email->set_subject('WebPA - Peer Feedback Comments Available');
+        $email->set_body($body);
+        $email->send();
+    }
+
+    $publishedDateQuery =
+        'INSERT INTO                 ' . APP__DB_TABLE_PREFIX . 'user_justification_publish_date ' .
+        'VALUES                      (?, NOW())';
+
+    $stmt = $DB->getConnection()->prepare($publishedDateQuery);
+
+    $stmt->bindValue(1, $user['assessment_id']);
+
+    $stmt->execute();
 } catch (\Doctrine\DBAL\Exception $e) {
     error_log('Message: ' . $e->getMessage() . ' - Trace: ' . $e->getTraceAsString());
 
-    $errors[] = 'Could not get the assessment users from the database.';
-}
-
-foreach ($assessmentUsers as $user) {
-    $hash = hash('sha256', $user['assessment_id'] . $user['user_id'] . random_int(0, 1000000));
-
-    $logReportIdQuery =
-        'INSERT INTO             ' . APP__DB_TABLE_PREFIX . 'user_justification_report ' .
-        'VALUES (?, ?, ?)';
-
-    $stmt = $DB->getConnection()->prepare($logReportIdQuery);
-
-    $stmt->bindValue(1, $hash);
-    $stmt->bindValue(2, $user['assessment_id']);
-    $stmt->bindValue(3, $user['user_id'], ParameterType::INTEGER);
-
-    $stmt->execute();
-
-    $email = new Email();
-
-    $body =
-        "Dear " . $user['forename'] . ", \n\n" .
-        "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
-        "Justification comments </a> for the marks you received from your peers for assessment '" .
-        $user['assessment_name'] ."' are now available for you to view, \n\n" .
-        "Many thanks,\n" .
-        "WebPA";
-
-    $email->set_to($user['email']);
-    $email->set_bcc(['christopher.mckenzie@ed.ac.uk', 'k.lyszkiewicz@ed.ac.uk', 'vanessa.mather@ed.ac.uk']);
-    $email->set_from(APP__EMAIL_NO_REPLY);
-    $email->set_subject('WebPA - Peer Feedback Comments Available');
-    $email->set_body($body);
-    $email->send();
-}
-
-// Close the comments edit
-$publishedDateQuery =
-    'INSERT INTO                 ' . APP__DB_TABLE_PREFIX . 'user_justification_publish_date ' .
-    'VALUES                      (?, NOW())';
-
-$stmt = $DB->getConnection()->prepare($publishedDateQuery);
-
-$stmt->bindValue(1, $user['assessment_id']);
-
-try {
-    $stmt->execute();
-} catch (\Doctrine\DBAL\Exception $e) {
-    $errors[] = 'Could not save the publish date for these reports.';
+    $errors[] = 'A database error was encountered when trying to generate the comment reports.';
 }
 
 // Begin the page

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Release feedback comments to students
+ *
+ * @copyright Loughborough University
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL version 3
+ *
+ * @link https://github.com/webpa/webpa
+ */
+
 require_once '../../../includes/inc_global.php';
 
 use Doctrine\DBAL\ParameterType;
@@ -16,7 +25,6 @@ $errors = null;
 
 // Process the form submission
 $assessmentId = Common::fetch_POST('assessment-id');
-
 
 if (empty($assessmentId)) {
     $errors[] = 'No assessment ID provided.';

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once '../../../includes/inc_global.php';
+
+use Doctrine\DBAL\ParameterType;
+use WebPA\includes\classes\Email;
+use WebPA\includes\functions\Common;
+
+if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
+    header('Location:' . APP__WWW . '/logout.php?msg=denied');
+
+    exit;
+}
+
+// Process the form submission
+$assessmentId = Common::fetch_POST('assessment-id');
+
+
+if (empty($assessmentId)) {
+
+} else  {
+
+}
+
+// Get every user in the assessment
+$userQuery =
+    'SELECT             a.assessment_id, ugm.user_id, u.email ' .
+    'FROM               ' . APP__DB_TABLE_PREFIX . 'assessment a ' .
+    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_group ug ' .
+    'ON                 ug.collection_id = a.collection_id ' .
+    'LEFT JOIN          ' . APP__DB_TABLE_PREFIX . 'user_group_member ugm ' .
+    'ON                 ugm.group_id = ug.group_id ' .
+    'LEFT JOIN          '. APP__DB_TABLE_PREFIX . 'user u ' .
+    'ON                 u.user_id = ugm.user_id ' .
+    'WHERE              a.assessment_id = ?';
+
+$assessmentUsers = $DB
+    ->getConnection()
+    ->fetchAllAssociative($userQuery, [$assessmentId], [ParameterType::STRING]);
+
+
+foreach ($assessmentUsers as $user) {
+    $hash = hash('sha256', $user['assessment_id'] . $user['user_id'] . random_int(0, 1000000));
+
+    $logReportIdQuery =
+        'INSERT INTO             ' . APP__DB_TABLE_PREFIX . 'user_justification_report ' .
+        'VALUES (?, ?, ?)';
+
+    $stmt = $DB->getConnection()->prepare($logReportIdQuery);
+
+    $stmt->bindValue(1, $hash);
+    $stmt->bindValue(2, $user['assessment_id']);
+    $stmt->bindValue(3, $user['user_id'], ParameterType::INTEGER);
+
+    $stmt->execute();
+
+    $email = new Email();
+
+
+    $body =
+        "Dear Andrew, \n\n" .
+        "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
+        "Justification comments </a> for the marks you received from your peers for assessment X are now available " .
+        "for you to view, \n\n" .
+        "Many thanks,\n" .
+        "WebPA";
+
+    $email->set_to( 'andrew.millington@ed.ac.uk'/* $user['email'] */);
+    $email->set_from(APP__EMAIL_NO_REPLY);
+    $email->set_subject('WebPA - Peer Feedback Comments Available');
+    $email->set_body("You know it's just the same as it was $hash");
+    $email->send();
+}
+
+// Close the comments edit
+$publishedDateQuery =
+    'INSERT INTO                 ' . APP__DB_TABLE_PREFIX . 'user_justification_publish_date ' .
+    'VALUES                      (?, NOW())';
+
+$stmt = $DB->getConnection()->prepare($publishedDateQuery);
+
+$stmt->bindValue(1, $user['assessment_id']);
+
+$stmt->execute();
+
+// Begin the page
+$UI->page_title = APP__NAME . ' ' . 'release student justification comments';
+$UI->menu_selected = 'my assessments';
+$UI->help_link = '?q=node/235';
+
+$UI->breadcrumbs = [
+    'home' => '../../',
+    'my assessments' => '../',
+    'review justifications' => null,
+];
+
+$UI->set_page_bar_button('List Assessments', '../../../../images/buttons/button_assessment_list.gif', '../');
+$UI->set_page_bar_button('Create Assessments', '../../../../images/buttons/button_assessment_create.gif', '../create/');
+
+$UI->head();
+
+$UI->content_start();
+
+//$UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', 'No changes have been saved. Please check the details in the form, and try again.');
+?>
+<div class="content_box">
+    <strong>Feedback Released</strong>
+<!-- DISPLAY ERRORS GENERATING FEEDBACK HERE -->
+    <p>
+        Feedback reports have been generated for all students. Links have been emailed to the students to let them view
+        feedback from their peers.
+    </p>
+</div>
+
+<?php
+
+$UI->content_end();

--- a/src/tutors/assessments/marks/review_justification.php
+++ b/src/tutors/assessments/marks/review_justification.php
@@ -241,16 +241,17 @@ $UI->draw_boxed_list(
 
     <h2>Student Justification Comments</h2>
 
-    <div style="display: flex; justify-content: flex-end">
-        <form action="release_comments.php" method="post">
-            <input type="hidden" name="assessment-id" value="<?= $assessment_id ?>">
-            <button type="submit">Release Comments</button>
-        </form>
-    </div>
+
     <div>
         <?php if (empty($groupComments)) : ?>
         <p>There are no comments to display</p>
         <?php else : ?>
+        <div style="display: flex; justify-content: flex-end">
+            <form action="release_comments.php" method="post">
+                <input type="hidden" name="assessment-id" value="<?= $assessment_id ?>">
+                <button type="submit">Release Comments</button>
+            </form>
+        </div>
         <?php foreach ($groupComments as $groupId => $comments) : ?>
         <section>
             <h3><?= $groupNameIdMap[$groupId] ?></h3>
@@ -273,13 +274,13 @@ $UI->draw_boxed_list(
             <?php endforeach; ?>
         </section>
         <?php endforeach; ?>
+        <div style="display: flex; justify-content: flex-end">
+            <form action="release_comments.php" method="post">
+                <input type="hidden" name="assessment-id" value="<?= $assessment_id ?>">
+                <button type="submit">Release Comments</button>
+            </form>
+        </div>
         <?php endif; ?>
-    </div>
-    <div style="display: flex; justify-content: flex-end">
-        <form action="release_comments.php" method="post">
-            <input type="hidden" name="assessment-id" value="<?= $assessment_id ?>">
-            <button type="submit">Release Comments</button>
-        </form>
     </div>
     <?php endif; ?>
 

--- a/src/tutors/assessments/marks/review_justification.php
+++ b/src/tutors/assessments/marks/review_justification.php
@@ -13,8 +13,6 @@ require_once '../../../includes/inc_global.php';
 
 use Doctrine\DBAL\ParameterType;
 use WebPA\includes\classes\Assessment;
-use WebPA\includes\classes\GroupHandler;
-use WebPA\includes\classes\XMLParser;
 use WebPA\includes\functions\Common;
 
 if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
@@ -90,9 +88,7 @@ if (($command) && ($assessment)) {
 // --------------------------------------------------------------------------------
 // Begin Page
 
-$page_title = 'review student justification comments';
-
-$UI->page_title = APP__NAME . ' ' . $page_title;
+$UI->page_title = APP__NAME . ' review student justification comments';
 $UI->menu_selected = 'my assessments';
 $UI->help_link = '?q=node/235';
 $UI->breadcrumbs = ['home' => '../../',
@@ -216,7 +212,7 @@ $UI->head();
       editLink.onclick = editCommentToggle;
     }
 
-    const editCommentForms = document.querySelectorAll('form');
+    const editCommentForms = document.querySelectorAll('form.edit-comment');
 
     editCommentForms.forEach(submitEditCommentForm);
   }
@@ -279,10 +275,10 @@ $UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', '
                     </p>
                     <a href="#" class="edit-toggle" id="edit-toggle-<?= $comment['id'] ?>">Edit</a>
                     <div class="hide">
-                        <form action="edit_comment.php" method="post">
+                        <form action="edit_comment.php" method="post" class="edit-comment">
                             <textarea name="comment" style="width:100%;"><?= $displayComment ?></textarea>
                             <input type="hidden" name="comment-id" value="<?= $comment['id'] ?>">
-                            <button type="submit">Edit</button>
+                            <button type="submit">Save</button>
                         </form>
                     </div>
                 </div>
@@ -294,7 +290,8 @@ $UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', '
     }
     ?>
     <div style="display: flex; justify-content: flex-end">
-        <form action="post">
+        <form action="release_comments.php" method="post">
+            <input type="hidden" name="assessment-id" value="<?= $assessment_id ?>">
             <button type="submit">Release Comments</button>
         </form>
     </div>
@@ -303,5 +300,3 @@ $UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', '
 <?php
 
 $UI->content_end();
-
-?>

--- a/src/tutors/assessments/marks/review_justification.php
+++ b/src/tutors/assessments/marks/review_justification.php
@@ -199,7 +199,7 @@ $UI->head();
 $UI->content_start();
 
 // TODO: Check this is needed
-$UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', 'No changes have been saved. Please check the details in the form, and try again.');
+//$UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', 'No changes have been saved. Please check the details in the form, and try again.');
 
 ?>
 

--- a/src/tutors/assessments/marks/review_justification.php
+++ b/src/tutors/assessments/marks/review_justification.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * Review and edit justification comments from students
+ *
+ * @copyright Loughborough University
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL version 3
+ *
+ * @link https://github.com/webpa/webpa
+ */
+
+require_once '../../../includes/inc_global.php';
+
+use Doctrine\DBAL\ParameterType;
+use WebPA\includes\classes\Assessment;
+use WebPA\includes\classes\GroupHandler;
+use WebPA\includes\classes\XMLParser;
+use WebPA\includes\functions\Common;
+
+if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
+    header('Location:' . APP__WWW . '/logout.php?msg=denied');
+
+    exit;
+}
+
+$assessment_id = Common::fetch_GET('a');
+
+$tab = Common::fetch_GET('tab');
+$year = Common::fetch_GET('y', date('Y'));
+
+$command = Common::fetch_POST('command');
+
+$list_url = "../index.php?tab={$tab}&y={$year}";
+
+$assessment = new Assessment($DB);
+
+if ($assessment->load($assessment_id)) {
+    // Not sure we need to load the assessment at the moment - anyways, here is the query to get the comments
+    $feedbackCommentsQuery =
+        'SELECT uj.id, uj.justification_text, mdj.moderated_comment, uj.group_id, ug.group_name ' .
+        'FROM ' . APP__DB_TABLE_PREFIX . 'user_justification uj ' .
+        'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'user_group ug ' .
+        'ON uj.group_id = ug.group_id ' .
+        'LEFT JOIN ' . APP__DB_TABLE_PREFIX . 'moderated_user_justification mdj ' .
+        'ON mdj.user_justification_id = uj.id ' .
+        'WHERE assessment_id = ? ' .
+        'ORDER BY group_id';
+
+    $comments = $DB
+        ->getConnection()
+        ->fetchAllAssociative($feedbackCommentsQuery, [$assessment_id], [ParameterType::STRING]);
+
+    $groupComments = [];
+    $groupNameIdMap = [];
+
+    // Format the comments into a friendly format to iterate through
+    foreach ($comments as $comment) {
+        // only add comments if we have a comment to add
+        if (!empty($comment['justification_text'])) {
+            $groupComments[$comment['group_id']][] = [
+                    'id' => $comment['id'],
+                    'comment' => $comment['justification_text'],
+                    'moderatedComment' => $comment['moderated_comment'],
+            ];
+        }
+
+        if (!array_key_exists($comment['group_id'], $groupNameIdMap)) {
+            $groupNameIdMap[$comment['group_id']] = $comment['group_name'];
+        }
+    }
+} else {
+    $assessment = null;
+}
+
+// --------------------------------------------------------------------------------
+// Process Form
+
+$errors = null;
+
+if (($command) && ($assessment)) {
+    switch ($command) {
+        case 'save':
+            // Generate hash for each user
+            // Save published date
+            // Generate email
+            break;
+    }
+}
+
+// --------------------------------------------------------------------------------
+// Begin Page
+
+$page_title = 'review student justification comments';
+
+$UI->page_title = APP__NAME . ' ' . $page_title;
+$UI->menu_selected = 'my assessments';
+$UI->help_link = '?q=node/235';
+$UI->breadcrumbs = ['home' => '../../',
+    'my assessments' => '../',
+    'review justifications' => null,];
+
+$UI->set_page_bar_button('List Assessments', '../../../../images/buttons/button_assessment_list.gif', '../');
+$UI->set_page_bar_button('Create Assessments', '../../../../images/buttons/button_assessment_create.gif', '../create/');
+
+$UI->head();
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-notify@0.5.5/dist/simple-notify.min.css" />
+<style>
+
+    table.grid th {
+        text-align: center;
+    }
+
+    table.grid td {
+        text-align: left;
+    }
+
+    span.id_number {
+        color: #666;
+    }
+    -->
+</style>
+<script src="https://cdn.jsdelivr.net/npm/simple-notify@0.5.5/dist/simple-notify.min.js"></script>
+<script>
+  function do_command (com) {
+    switch (com) {
+      default :
+        document.groupmark_form.command.value = com
+        document.groupmark_form.submit()
+    }
+  }
+
+  const editCommentToggle = function (e) {
+    e.preventDefault();
+
+    toggleCommentDiv(e.target);
+  }
+
+  function toggleCommentDiv(target) {
+    const formDiv = target.nextElementSibling;
+
+    if (target.innerText === 'Edit') {
+      target.innerText = 'Hide';
+      formDiv.classList.remove('hide');
+    } else {
+      target.innerText = 'Edit';
+      formDiv.classList.add('hide');
+    }
+  }
+
+  const submitEditCommentForm = function (form) {
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+
+      const data = e.target;
+      const commentId = data['comment-id'].value;
+
+      fetch(data.getAttribute('action'), {
+        method: data.getAttribute('method'),
+        body: new FormData(data)
+      }).then(response => {
+        if (!response.ok) {
+          throw new Error('Comment not updated');
+        }
+
+        new Notify({
+          status: 'success',
+          title: 'Comment Updated',
+          text: 'Your edit has been saved',
+          effect: 'slide',
+          speed: 300,
+          customClass: null,
+          customIcon: null,
+          showIcon: true,
+          showCloseButton: true,
+          autoclose: true,
+          autotimeout: 5000,
+          gap: 20,
+          distance: 20,
+          type: 1,
+          position: 'right top'
+        });
+
+        toggleCommentDiv(document.getElementById(`edit-toggle-${commentId}`));
+
+        const comment = document.getElementById(`comment-${commentId}`);
+
+        comment.innerText = data.comment.value;
+      })
+      .catch(error => {
+        new Notify({
+            status: 'error',
+            title: 'Error',
+            text: 'A problem occurred. Your comment was not saved',
+            effect: 'slide',
+            speed: 300,
+            customClass: null,
+            customIcon: null,
+            showIcon: true,
+            showCloseButton: true,
+            autoclose: false,
+            autotimeout: 5000,
+            gap: 20,
+            distance: 20,
+            type: 1,
+            position: 'right top'
+          });
+        });
+      });
+  }
+
+  function addHandlers() {
+    const editLinks = [...document.getElementsByClassName('edit-toggle')];
+
+    for (editLink of editLinks) {
+      editLink.onclick = editCommentToggle;
+    }
+
+    const editCommentForms = document.querySelectorAll('form');
+
+    editCommentForms.forEach(submitEditCommentForm);
+  }
+
+  window.onload = addHandlers;
+</script>
+<?php
+$UI->content_start();
+
+$UI->draw_boxed_list($errors, 'error_box', 'The following errors were found:', 'No changes have been saved. Please check the details in the form, and try again.');
+
+?>
+
+<p>
+    On this page you can review justification comments from students and edit them before releasing them to students.
+    Please note that if you edit a justification, the original justification will be retained but the edited version is
+    the only one that will show to the student.
+</p>
+
+<div class="content_box">
+
+    <?php
+    if (!$assessment) {
+        ?>
+        <div class="nav_button_bar">
+            <a href="<?= $list_url ?>"><img src="../../../images/buttons/arrow_green_left.gif" alt="back -"> back to
+                assessments list</a>
+        </div>
+
+        <p>The assessment you selected could not be loaded for some reason - please go back and try again.</p>
+        <?php
+    } else {
+        ?>
+        <div class="nav_button_bar">
+            <table cellpadding="0" cellspacing="0" width="100%">
+                <tr>
+                    <td><a href="<?php echo $list_url; ?>"><img src="../../../images/buttons/arrow_green_left.gif"
+                                                                alt="back -"> back to assessment list</a></td>
+                </tr>
+            </table>
+        </div>
+
+        <h2>Student Justification Comments</h2>
+
+        <div style="display: flex; justify-content: flex-end">
+            <form action="post">
+                <button type="submit">Release Comments</button>
+            </form>
+        </div>
+        <div>
+            <?php foreach ($groupComments as $groupId => $comments) : ?>
+            <section>
+                <h3><?= $groupNameIdMap[$groupId] ?></h3>
+
+                <?php foreach ($comments as $comment) : ?>
+                <?php $displayComment = !empty($comment['moderatedComment']) ? $comment['moderatedComment'] : $comment['comment']; ?>
+                <div style="margin-bottom: 2em;">
+                    <p id="comment-<?= $comment['id'] ?>">
+                        <?= $displayComment ?>
+                    </p>
+                    <a href="#" class="edit-toggle" id="edit-toggle-<?= $comment['id'] ?>">Edit</a>
+                    <div class="hide">
+                        <form action="edit_comment.php" method="post">
+                            <textarea name="comment" style="width:100%;"><?= $displayComment ?></textarea>
+                            <input type="hidden" name="comment-id" value="<?= $comment['id'] ?>">
+                            <button type="submit">Edit</button>
+                        </form>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </section>
+            <?php endforeach; ?>
+        </div>
+    <?php
+    }
+    ?>
+    <div style="display: flex; justify-content: flex-end">
+        <form action="post">
+            <button type="submit">Release Comments</button>
+        </form>
+    </div>
+</div>
+
+<?php
+
+$UI->content_end();
+
+?>


### PR DESCRIPTION
This pull request allows tutors to create assessments where student justification for marks can be shared with students, so they have a better understanding of why the were marked the way they were by their peers.

Changes include:

* Mark assessment feedback comments as visible to students
* Warn students their comments will be visible to their peers
* Allow tutors to moderate comments prior to publication
* Remove most "advanced" feature toggles to clean up the UI
* Add new icons for the assessment actions as could not find originals used
* Prevent further edits to comments once the reports have been published
* Students emailed when comments report is ready. They won't need to login and instead will be provided with a link and a long hash to prevent guessing of reports