### PR TITLE
Fix Form Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Split 100 forms can now be imported into WebPA. Previously, only likert scale forms could be imported (PR #98)
+- XML Validation errors now display when uploading an invalid form (PR #98)
 
 ## [3.2.1] - 2021-12-10
 ### Fixed

--- a/src/includes/functions/XML.php
+++ b/src/includes/functions/XML.php
@@ -23,9 +23,11 @@ class XML
         $objDom->loadXML($xml);
 
         if (!$objDom->schemaValidate($xsd)) {
-            libxml_get_errors();
-            return false;
+            return libxml_get_errors();
         }
-        return true;
+
+        libxml_use_internal_errors(false);
+
+        return [];
     }
 }

--- a/src/tutors/forms/import/schema.xsd
+++ b/src/tutors/forms/import/schema.xsd
@@ -27,7 +27,7 @@
       <xs:sequence>
         <xs:element ref="text" />
         <xs:element ref="desc" />
-        <xs:element ref="range" />
+        <xs:element ref="range" minOccurs="0" />
         <xs:element ref="scorelabel0" minOccurs="0" />
         <xs:element ref="scorelabel1" minOccurs="0" />
         <xs:element ref="scorelabel2" minOccurs="0" />

--- a/src/tutors/forms/import/xml_file.php
+++ b/src/tutors/forms/import/xml_file.php
@@ -21,10 +21,9 @@ if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
     exit;
 }
 
-$errno = -1;
-foreach ($_FILES as $file) {
-    $errno = $file['error'];
-}
+$errno = $_FILES['uploadedfile']['error'];
+
+$errno = 1;
 
 if ($errno == 0) {
 
@@ -35,9 +34,9 @@ if ($errno == 0) {
     $localfile = file_get_contents($source);
 
     //validate the XML
-    $isValid = XML::validate($localfile, 'schema.xsd');
+    $xmlErrors = XML::validate($localfile, 'schema.xsd');
 
-    if ($isValid === true) {
+    if (empty($xmlErrors)) {
         //get the ID for the current User
         $staff_id = $_user->id;
 
@@ -106,10 +105,18 @@ if ($errno == 0) {
             $action_notify = '<p>The form has been uploaded and can be found in your <a href="/tutors/forms">my forms</a> list.</p>';
         }
     } else {
-        $action_notify = '<p>The import has failed due to the following reasons &#59; <br/>' . print_r($isValid, true) . '</p>';
+        $action_notify = '<p>The import has failed due to the following reasons:</p>';
+        $action_notify .= '<ul>';
+
+        foreach ($xmlErrors as $xmlError) {
+            $action_notify .= '<li>' . $xmlError->message . '</li>';
+        }
+
+        $action_notify .= '</ul>';
     }
 } elseif (isset($FILE_ERRORS[$errno])) {
-    $action_notify = "<p>{$FILE_ERRORS[$errno]}</p>";
+    // $FILE_ERRORS is a global variable imported from the inc_global file
+    $action_notify = "<div class='error_box'><p>{$FILE_ERRORS[$errno]}</p></div>";
 } else {
     $action_notify = '<p>Unable to upload file.</p>';
 }
@@ -129,8 +136,8 @@ $UI->content_start();
 
 ?>
 <div class="content_box">
-  <h2>form loading</h2>
-  <?php echo $action_notify; ?>
+  <h2>Form Upload</h2>
+  <?= $action_notify; ?>
 </div>
 <?php
 

--- a/src/tutors/forms/import/xml_file.php
+++ b/src/tutors/forms/import/xml_file.php
@@ -23,8 +23,6 @@ if (!Common::check_user($_user, APP__USER_TYPE_TUTOR)) {
 
 $errno = $_FILES['uploadedfile']['error'];
 
-$errno = 1;
-
 if ($errno == 0) {
 
   //file information
@@ -118,7 +116,7 @@ if ($errno == 0) {
     // $FILE_ERRORS is a global variable imported from the inc_global file
     $action_notify = "<div class='error_box'><p>{$FILE_ERRORS[$errno]}</p></div>";
 } else {
-    $action_notify = '<p>Unable to upload file.</p>';
+    $action_notify = '<div class="error_box"></div><p>Unable to upload file.</p></div>';
 }
 
 $UI->page_title = APP__NAME . ' load form';

--- a/src/tutors/forms/import/xml_file.php
+++ b/src/tutors/forms/import/xml_file.php
@@ -52,12 +52,17 @@ if ($errno == 0) {
 
         //check that the form doesn't already exist for the user or for another
         $resultsQuery =
-        'SELECT * ' .
-        'FROM ' . APP__DB_TABLE_PREFIX . 'form f ' .
-        'WHERE form_id = ? ' .
-        'AND form_name = ?';
+            'SELECT             f.form_id ' .
+            'FROM               ' . APP__DB_TABLE_PREFIX . 'form f ' .
+            'INNER JOIN         ' . APP__DB_TABLE_PREFIX . 'form_module fm ' .
+            'ON                 f.form_id = fm.form_id ' .
+            'INNER JOIN         ' . APP__DB_TABLE_PREFIX . 'user_module um ' .
+            'ON                 fm.module_id = um.module_id ' .
+            'WHERE              f.form_id = ? ' .
+            'AND                f.form_name = ? ' .
+            'AND                um.user_id = ?';
 
-        $results = $DB->getConnection()->fetchAssociative($resultsQuery, [$form_id, $formname], [ParameterType::STRING, ParameterType::STRING]);
+        $results = $DB->getConnection()->fetchAssociative($resultsQuery, [$form_id, $formname, $_user->id], [ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER]);
 
         if ($results) {
             //we need to prompt that they are the same - or send to clone form
@@ -91,14 +96,14 @@ if ($errno == 0) {
           ->createQueryBuilder()
           ->insert(APP__DB_TABLE_PREFIX . 'form_module')
           ->values([
-              'form_id' => $new_id,
-              'module_id' => $_module_id,
+              'form_id' => '?',
+              'module_id' => '?',
           ])
           ->setParameter(0, $new_id)
           ->setParameter(1, $_module_id, ParameterType::INTEGER)
           ->execute();
 
-            $action_notify = "<p>The form has been uploaded and can be found in your <a href=\"index.php\">'my forms'</a> list.</p>";
+            $action_notify = '<p>The form has been uploaded and can be found in your <a href="/tutors/forms">my forms</a> list.</p>';
         }
     } else {
         $action_notify = '<p>The import has failed due to the following reasons &#59; <br/>' . print_r($isValid, true) . '</p>';


### PR DESCRIPTION
This PR fixes the form import function for WebPA. Previously Split 100 forms were prevented from being uploaded by XML validation. This was because the child element, `range` was not present in the `question` element. This field has now been changed to be optional.

As part of this PR, we have also fixed the error handling so errors are now correctly displayed when an issue is encountered uploading or pasting in an XML form export.