### PR TITLE
Ensure emails are sent as html when releasing justification comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.3.0-RC] - 2022-10-26
 ### Added
-- Justification comments from students about why they gave scores can now be viewed by students after being moderated by academic staff (PR #97)
+- Justification comments from students about why they gave scores can now be viewed by students after being moderated by academic staff (PR #97, #99)
 
 ## [3.2.2] - 2022-10-17
 ### Fixed

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -79,10 +79,10 @@ try {
             "WebPA";
 
         $email->set_to($user['email']);
-        $email->set_bcc(['christopher.mckenzie@ed.ac.uk', 'k.lyszkiewicz@ed.ac.uk', 'vanessa.mather@ed.ac.uk']);
         $email->set_from(APP__EMAIL_NO_REPLY);
         $email->set_subject('WebPA - Peer Feedback Comments Available');
         $email->set_body($body);
+        $email->set_message_type('html');
         $email->send();
     }
 

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -71,12 +71,13 @@ try {
         $email = new Email();
 
         $body =
-            "Dear " . $user['forename'] . ", \n\n" .
+            'Dear ' . $user['forename'] . ', <br /><br />' .
             "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
-            "Justification comments </a> for the marks you received from your peers for assessment '" .
-            $user['assessment_name'] ."' are now available for you to view, \n\n" .
-            "Many thanks,\n" .
-            "WebPA";
+            'Comments providing justification</a> for the marks you received from your peers for assesement ' .
+            $user['assessment_name'] . ' are now ' .
+            'available</a> for you to view, <br /><br />' .
+            'Many thanks,<br />' .
+            'WebPA';
 
         $email->set_to($user['email']);
         $email->set_from(APP__EMAIL_NO_REPLY);


### PR DESCRIPTION
The justification comment release email to students contains a link to a report for student to view peer feedback. The email is currently sent as plain text, meaning the link is not encoded properly.

This PR changes the email type to HTML so that the email is displayed correctly in email clients. It also removes a bcc item that was left in for internal testing purposes.