### PR TITLE
Fix hardcoded url in release comments email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed
 - The URL for the comments report was hardcoded instead of being retrieved from the application's settings. This has now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [3.3.0-RC1] - 2023-01-04
+### Fixed
+- The URL for the comments report was hardcoded instead of being retrieved from the application's settings. This has now
+been resolved (PR #XXX)
 
 ## [3.3.0-RC] - 2022-10-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ been resolved (PR #XXX)
 
 ## [1.1.0.1] - 2008-07-19
 
-[Unreleased]: https://github.com/WebPA/WebPA/compare/v3.3.0-RC...HEAD
+[Unreleased]: https://github.com/WebPA/WebPA/compare/v3.3.0-RC1...HEAD
+[3.3.0-RC1]: https://github.com/WebPA/WebPA/compare/v3.3.0-RC...v3.3.0-RC1
 [3.3.0-RC]: https://github.com/WebPA/WebPA/compare/v3.2.2...v3.3.0-RC
 [3.2.2]: https://github.com/WebPA/WebPA/compare/v3.2.1...v3.2.2
 [3.2.1]: https://github.com/WebPA/WebPA/compare/v3.2.0...v3.2.1

--- a/src/includes/inc_global.php
+++ b/src/includes/inc_global.php
@@ -94,7 +94,7 @@ $INSTALLED_MODS = [];
 define('APP__NAME', 'WebPA OS');
 define('APP__TITLE', 'WebPA OS : Online Peer Assessment System');
 define('APP__ID', 'webpa');
-define('APP__VERSION', '3.3.0-RC');
+define('APP__VERSION', '3.3.0-RC1');
 define('APP__DESCRIPTION', 'WebPA, an Open source, online peer assessment system.');
 define('APP__KEYWORDS', 'peer assessment, online, peer, assessment, tools, open source');
 

--- a/src/tutors/assessments/marks/release_comments.php
+++ b/src/tutors/assessments/marks/release_comments.php
@@ -72,7 +72,7 @@ try {
 
         $body =
             "Dear " . $user['forename'] . ", \n\n" .
-            "<a href=\"https://www-test.webpa.is.ed.ac.uk/students/assessments/reports/justification_comments.php?r=$hash\">" .
+            "<a href=\"" . APP__WWW . "/students/assessments/reports/justification_comments.php?r=$hash\">" .
             "Justification comments </a> for the marks you received from your peers for assessment '" .
             $user['assessment_name'] ."' are now available for you to view, \n\n" .
             "Many thanks,\n" .


### PR DESCRIPTION
Noticed that I'd left a hardcoded URL in the release comments email, meaning reports were being directed to a university of Edinburgh address instead of whoever was hosting the application. 

This fix resolves this issue.