### PR TITLE
Issue #104 creating assessments fails if the feedback form title excedes 45 chars

### DIFF
--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -168,10 +168,10 @@ class WizardStep2
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td>
-                                    <label class="small" for="feedback_name">Feedback Form Title </label>
+                                    <label class="small" for="feedback_name" style="margin-right: 10px;">Feedback Form Title</label>
                                 </td>
                                 <td>
-                                    <input type="text" name="feedback_name" id="feedback_name" maxlength="100" size="40"
+                                    <input type="text" name="feedback_name" id="feedback_name" maxlength="40" size="40"
                                            value="<?php echo $this->wizard->get_field('feedback_name'); ?>">
                                 </td>
                             </tr>

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -171,8 +171,8 @@ class WizardStep2
                                     <label class="small" for="feedback_name" style="margin-right: 10px;">Feedback Form Title</label>
                                 </td>
                                 <td>
-                                    <input type="text" name="feedback_name" id="feedback_name" maxlength="40" size="40"
-                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>">&nbsp;max 40 characters.
+                                    <input type="text" name="feedback_name" id="feedback_name" maxlength="45" size="45"
+                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>">
                                 </td>
                             </tr>
                             <tr>

--- a/src/tutors/assessments/create/class_wizardstep_2.php
+++ b/src/tutors/assessments/create/class_wizardstep_2.php
@@ -172,7 +172,7 @@ class WizardStep2
                                 </td>
                                 <td>
                                     <input type="text" name="feedback_name" id="feedback_name" maxlength="40" size="40"
-                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>">
+                                           value="<?php echo $this->wizard->get_field('feedback_name'); ?>">&nbsp;max 40 characters.
                                 </td>
                             </tr>
                             <tr>

--- a/src/tutors/assessments/edit/edit_assessment.php
+++ b/src/tutors/assessments/edit/edit_assessment.php
@@ -500,7 +500,7 @@ if (!$assessment) {
         <table class="form" cellpadding="2" cellspacing="2">
         <tr>
           <td><label for="feedback_title">Title &nbsp;</label></td>
-          <td><input type="text" name="feedback_title" value="<?php echo $assessment->feedback_name; ?>" size="40" maxlength="40"/></td>
+          <td><input type="text" name="feedback_title" value="<?php echo $assessment->feedback_name; ?>" size="40" maxlength="40"/>&nbsp;max 40 characters.</td>
         </tr>
         <tr>
           <td><input type="radio" name="allow_assessment_feedback" id="allow_assessment_feedback_yes" value="1" <?php echo $assessment->allow_assessment_feedback ? 'checked="checked"' : ''; ?> /></td>

--- a/src/tutors/assessments/edit/edit_assessment.php
+++ b/src/tutors/assessments/edit/edit_assessment.php
@@ -500,7 +500,7 @@ if (!$assessment) {
         <table class="form" cellpadding="2" cellspacing="2">
         <tr>
           <td><label for="feedback_title">Title &nbsp;</label></td>
-          <td><input type="text" name="feedback_title" value="<?php echo $assessment->feedback_name; ?>" size="40" maxlength="40"/>&nbsp;max 40 characters.</td>
+          <td><input type="text" name="feedback_title" value="<?php echo $assessment->feedback_name; ?>" size="45" maxlength="45"/></td>
         </tr>
         <tr>
           <td><input type="radio" name="allow_assessment_feedback" id="allow_assessment_feedback_yes" value="1" <?php echo $assessment->allow_assessment_feedback ? 'checked="checked"' : ''; ?> /></td>


### PR DESCRIPTION
Fixed the issue by setting the same maxlength for the feedback title text when creating an assessment.