### PR TITLE
Load Feather Icons Locally Instead of via a CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 *.orig
 .env
 /src/mod/**
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The icon pack, feather-icons, was loaded via a Content Delivery Network. If 
+the network was not available, no icons would display in WebPA. This change 
+makes the icon pack load from a local installation instead (PR #107)
 
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ student with an individual grade. The individual grade reflects the students con
 
 ## Requirements
 
+### PHP
 The following versions of PHP are supported for the latest version of WebPA:
 
 * PHP 7.4
@@ -17,6 +18,16 @@ Your PHP instance must also have the following extensions enabled:
 * MySQLi
 * Sessions
 * XML
+
+### NPM
+Node package manager is required to install feather-icons, an icon package used by WebPA. Once you have downloaded WebPA
+navigate to its root on the command line and run:
+
+- `npm install`
+- `npm run build`
+
+The first command will retrieve the feather-icons package and the second will move the relevant files to WebPA's _js_ 
+directory for use in the application.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "WebPA",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "feather-icons": "^4.29.0"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/core-js": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.0.tgz",
+      "integrity": "sha512-hQotSSARoNh1mYPi9O2YaWeiq/cEB95kOrFb4NCrO4RIFt1qqNpKsaE+vy/L3oiqvND5cThqXzUU3r9F7Efztg==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/feather-icons": {
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.0.tgz",
+      "integrity": "sha512-Y7VqN9FYb8KdaSF0qD1081HCkm0v4Eq/fpfQYQnubpqi0hXx14k+gF9iqtRys1SIcTEi97xDi/fmsPFZ8xo0GQ==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "core-js": "^3.1.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "copy": "cp -r node_modules/feather-icons/dist/* src/js",
+    "build": "npm run copy"
+  },
+  "dependencies": {
+    "feather-icons": "^4.29.0"
+  }
+}

--- a/src/tutors/assessments/index.php
+++ b/src/tutors/assessments/index.php
@@ -87,7 +87,7 @@ $UI->set_page_bar_button('Create Assessments', '../../../images/buttons/button_a
 $UI->head();
 $change_onclick = ' onclick="change_academic_year()"';
 ?>
-<script src="https://unpkg.com/feather-icons"></script>
+<script src="/js/feather.js"></script>
 <script>
   function change_academic_year() {
     year_sbox = document.getElementById('academic_year');


### PR DESCRIPTION
The CDN we use to load feather-icons has gone down a few times recently, resulting in some users now seeing icons properly in WebPA.

This PR updates our feather icons installation so the assets are stored and retrieved locally instead of from the cloud