### PR TITLE
Issue #108 Viewing my assessments fails for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 the network was not available, no icons would display in WebPA. This change 
 makes the icon pack load from a local installation instead (PR #107)
 
+### Fixed
+- Fixed an issue where viewing My Assessments page would crash for new users (PR #110)
+
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed
 - The URL for the comments report was hardcoded instead of being retrieved from the application's settings. This has now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the network was not available, no icons would display in WebPA. This change
 makes the icon pack load from a local installation instead (PR #107)
 
 ### Fixed
-- Fixed an issue where viewing My Assessments page would crash for new users (PR #110)
+- Fixed an issue where viewing my assessments page would crash for new users (PR #110)
 
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed

--- a/src/students/assessments/index.php
+++ b/src/students/assessments/index.php
@@ -30,7 +30,7 @@ $group_handler = new GroupHandler();
 
 $collections = $group_handler->get_member_collections($_user->id, 'assessment');
 
-$collection_ids = ArrayFunctions::array_extract_column($collections, 'collection_id');
+$collection_ids = empty($collections) ? [] : ArrayFunctions::array_extract_column($collections, 'collection_id');
 
 // Get a list of assessments that match the user's collections (for this year)
 


### PR DESCRIPTION
When a new user is created and do not have any collections linked to them, when they visit the _My Assessments_ page, it crushes. This is because the current logic retrieves this user's collections into an array which passed on to the _array_extract_column_ function which currently returns null. This null causes the following assessments query to fail as it expects the datatype to be an array.

This PR fixes this issue by ensuring that an empty array is passed to the assessments query instead of a null.