### PR TITLE
Issue-82-Inconsistencies-with-DOC__ROOT

### DIFF
--- a/src/tutors/forms/edit/add_question/index.php
+++ b/src/tutors/forms/edit/add_question/index.php
@@ -46,14 +46,14 @@ if ($form) {
     $valid_types = ['likert', 'split100'];
 
     if ($form->type=='split100') {
-        $wizard_path = DOC__ROOT . '/tutors/forms/edit/add_question/' . $form->type .'/';
+        $wizard_path = DOC__ROOT . 'tutors/forms/edit/add_question/' . $form->type .'/';
 
         $wizard->add_step(1, $wizard_path.'class_wizardstep_1.php');
         $wizard->add_step(2, $wizard_path.'class_wizardstep_2.php');
 
         $wizard->show_steps(1); // Hide the last step from the user
     } else {
-        $wizard_path = DOC__ROOT . '/tutors/forms/edit/add_question/' . $form->type .'/';
+        $wizard_path = DOC__ROOT . 'tutors/forms/edit/add_question/' . $form->type .'/';
 
         $wizard->add_step(1, $wizard_path.'class_wizardstep_1.php');
         $wizard->add_step(2, $wizard_path.'class_wizardstep_2.php');

--- a/src/tutors/forms/edit/edit_question/index.php
+++ b/src/tutors/forms/edit/edit_question/index.php
@@ -45,14 +45,14 @@ if ($form) {
     $valid_types = ['likert', 'split100'];
 
     if ($form->type=='split100') {
-        $wizard_path = DOC__ROOT . '/tutors/forms/edit/edit_question/' . $form->type .'/';
+        $wizard_path = DOC__ROOT . 'tutors/forms/edit/edit_question/' . $form->type .'/';
 
         $wizard->add_step(1, $wizard_path.'class_wizardstep_1.php');
         $wizard->add_step(2, $wizard_path.'class_wizardstep_2.php');
 
         $wizard->show_steps(1); // Hide the last step from the user
     } else {
-        $wizard_path = DOC__ROOT . '/tutors/forms/edit/edit_question/' . $form->type .'/';
+        $wizard_path = DOC__ROOT . 'tutors/forms/edit/edit_question/' . $form->type .'/';
 
         $wizard->add_step(1, $wizard_path.'class_wizardstep_1.php');
         $wizard->add_step(2, $wizard_path.'class_wizardstep_2.php');


### PR DESCRIPTION
A fix for [$issue82](https://github.com/WebPA/WebPA/issues/82).

_The DOC__ROOT const is supposed to be set with a trailing forward slash but in at least one of its use cases, we concatenate with a string that leads with a forward slash, causing a double forward slash in the path.
It appears that Apache will handle this gracefully but NginX does not and will fail to find the included file.
Suggested fix is to remove any forward slashes at the start of strings concatenated with the DOC__ROOT constant._

The fix does as sugessted, removes any extra forward slashes.