### PR TITLE
Issue #68 - Make upload file required on form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 the network was not available, no icons would display in WebPA. This change 
 makes the icon pack load from a local installation instead (PR #107)
 
+### Fixed
+- Fixed an issue where uploading data without choosing a file would result in a page crash  (PR#112)
+
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed
 - The URL for the comments report was hardcoded instead of being retrieved from the application's settings. This has now

--- a/src/admin/load/index.php
+++ b/src/admin/load/index.php
@@ -109,7 +109,7 @@ $pasteinstruction ='Copy and paste the contents of the file you want to add to t
       <?php echo $filename; ?>
     </td>
     <td>
-      <input name="uploadedfile" type="file" />
+      <input name="uploadedfile" type="file" required />
     </td>
 
   </tr>


### PR DESCRIPTION
As an admin when you upload data without choosing a file, the page crashes. This PR sets the file upload as required before the form can be submitted.