### PR TITLE
Issue #83 - User delete query incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 the network was not available, no icons would display in WebPA. This change 
 makes the icon pack load from a local installation instead (PR #107)
 
+### Fixed
+- When deleting a user, the process tries to delete all the forms linked to that user although there is no relationship 
+between the user and the form in the database. This PR fixes that. (PR #113)
+
 ## [3.3.0-RC1] - 2023-01-04
 ### Fixed
 - The URL for the comments report was hardcoded instead of being retrieved from the application's settings. This has now

--- a/src/includes/classes/User.php
+++ b/src/includes/classes/User.php
@@ -258,12 +258,6 @@ class User
         );
 
         $dbConn->executeQuery(
-            'DELETE FROM ' . APP__DB_TABLE_PREFIX . 'form WHERE form_owner_id = ?',
-            [$this->id],
-            [ParameterType::INTEGER]
-        );
-
-        $dbConn->executeQuery(
             'DELETE FROM ' . APP__DB_TABLE_PREFIX . 'user_justification WHERE marked_user_id = ? OR user_id = ?',
             [$this->id, $this->id],
             [ParameterType::INTEGER, ParameterType::INTEGER]


### PR DESCRIPTION
In the User class, the delete function tries to delete all the forms linked to the User when there is not link between a user and a form. This PR fixes this issue by removing the query from the deletion steps